### PR TITLE
Scaffold SATORI Audit plugin structure

### DIFF
--- a/admin/class-satori-audit-admin.php
+++ b/admin/class-satori-audit-admin.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Admin menu registration and screen bootstrap.
+ *
+ * @package Satori_Audit
+ */
+
+declare( strict_types=1 );
+
+namespace Satori_Audit\Admin;
+
+use Satori_Audit\Admin\Screens\Satori_Audit_Screen_Archive;
+use Satori_Audit\Admin\Screens\Satori_Audit_Screen_Dashboard;
+use Satori_Audit\Admin\Screens\Satori_Audit_Screen_Settings;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register admin menus and bootstrap screen controllers.
+ */
+class Satori_Audit_Admin {
+    /**
+     * Dashboard screen controller.
+     *
+     * @var Satori_Audit_Screen_Dashboard
+     */
+    private Satori_Audit_Screen_Dashboard $dashboard_screen;
+
+    /**
+     * Archive screen controller.
+     *
+     * @var Satori_Audit_Screen_Archive
+     */
+    private Satori_Audit_Screen_Archive $archive_screen;
+
+    /**
+     * Settings screen controller.
+     *
+     * @var Satori_Audit_Screen_Settings
+     */
+    private Satori_Audit_Screen_Settings $settings_screen;
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        $this->dashboard_screen = new Satori_Audit_Screen_Dashboard();
+        $this->archive_screen   = new Satori_Audit_Screen_Archive();
+        $this->settings_screen  = new Satori_Audit_Screen_Settings();
+
+        add_action( 'satori_audit_register_admin_screens', [ $this, 'register_menus' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+    }
+
+    /**
+     * Register menu and submenu pages for the plugin.
+     */
+    public function register_menus(): void {
+        $capability = 'manage_options';
+
+        add_menu_page(
+            __( 'SATORI Audit', 'satori-audit' ),
+            __( 'SATORI Audit', 'satori-audit' ),
+            $capability,
+            'satori-audit',
+            [ $this->dashboard_screen, 'render' ],
+            'dashicons-analytics',
+            58
+        );
+
+        add_submenu_page(
+            'satori-audit',
+            __( 'Audit Dashboard', 'satori-audit' ),
+            __( 'Dashboard', 'satori-audit' ),
+            $capability,
+            'satori-audit',
+            [ $this->dashboard_screen, 'render' ]
+        );
+
+        add_submenu_page(
+            'satori-audit',
+            __( 'Audit Archive', 'satori-audit' ),
+            __( 'Archive', 'satori-audit' ),
+            $capability,
+            'satori-audit-archive',
+            [ $this->archive_screen, 'render' ]
+        );
+
+        add_submenu_page(
+            'satori-audit',
+            __( 'Audit Settings', 'satori-audit' ),
+            __( 'Settings', 'satori-audit' ),
+            $capability,
+            'satori-audit-settings',
+            [ $this->settings_screen, 'render' ]
+        );
+    }
+
+    /**
+     * Enqueue placeholder assets for admin screens.
+     */
+    public function enqueue_assets(): void {
+        $screen = get_current_screen();
+
+        if ( ! $screen || false === strpos( (string) $screen->base, 'satori-audit' ) ) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'satori-audit-admin',
+            SATORI_AUDIT_PLUGIN_URL . 'assets/css/admin.css',
+            [],
+            SATORI_AUDIT_VERSION
+        );
+
+        wp_enqueue_script(
+            'satori-audit-admin',
+            SATORI_AUDIT_PLUGIN_URL . 'assets/js/admin.js',
+            [ 'jquery' ],
+            SATORI_AUDIT_VERSION,
+            true
+        );
+    }
+}

--- a/admin/screens/class-satori-audit-screen-archive.php
+++ b/admin/screens/class-satori-audit-screen-archive.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Archive admin screen.
+ *
+ * @package Satori_Audit
+ */
+
+declare( strict_types=1 );
+
+namespace Satori_Audit\Admin\Screens;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Render the Archive page for SATORI Audit.
+ */
+class Satori_Audit_Screen_Archive {
+    /**
+     * Display placeholder archive content.
+     */
+    public function render(): void {
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'SATORI Audit – Archive', 'satori-audit' ) . '</h1>';
+        echo '<p>' . esc_html__( 'A sortable archive of monthly reports will appear here.', 'satori-audit' ) . '</p>';
+        echo '<div class="satori-audit-placeholder">' . esc_html__( 'Archive list table coming soon.', 'satori-audit' ) . '</div>';
+        echo '</div>';
+    }
+}

--- a/admin/screens/class-satori-audit-screen-dashboard.php
+++ b/admin/screens/class-satori-audit-screen-dashboard.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Dashboard admin screen.
+ *
+ * @package Satori_Audit
+ */
+
+declare( strict_types=1 );
+
+namespace Satori_Audit\Admin\Screens;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Render the Dashboard page for SATORI Audit.
+ */
+class Satori_Audit_Screen_Dashboard {
+    /**
+     * Display placeholder dashboard content.
+     */
+    public function render(): void {
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'SATORI Audit – Dashboard', 'satori-audit' ) . '</h1>';
+        echo '<p>' . esc_html__( 'This screen will show the current period report, generation controls, and quick exports.', 'satori-audit' ) . '</p>';
+        echo '<div class="satori-audit-placeholder">' . esc_html__( 'Dashboard widgets and report preview coming soon.', 'satori-audit' ) . '</div>';
+        echo '</div>';
+    }
+}

--- a/admin/screens/class-satori-audit-screen-settings.php
+++ b/admin/screens/class-satori-audit-screen-settings.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Settings admin screen.
+ *
+ * @package Satori_Audit
+ */
+
+declare( strict_types=1 );
+
+namespace Satori_Audit\Admin\Screens;
+
+use Satori_Audit\Includes\Satori_Audit_Plugin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Render the Settings page for SATORI Audit.
+ */
+class Satori_Audit_Screen_Settings {
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( 'satori_audit_register_settings', [ $this, 'register_settings' ] );
+    }
+
+    /**
+     * Register a placeholder settings group and sections.
+     */
+    public function register_settings(): void {
+        register_setting( 'satori_audit_settings', 'satori_audit_settings', [ $this, 'sanitize_settings' ] );
+
+        add_settings_section(
+            'satori_audit_service_details',
+            __( 'Service Details', 'satori-audit' ),
+            [ $this, 'render_service_details_intro' ],
+            'satori_audit_settings'
+        );
+    }
+
+    /**
+     * Sanitize settings before saving.
+     *
+     * @param mixed $settings Submitted settings.
+     *
+     * @return array
+     */
+    public function sanitize_settings( $settings ): array {
+        if ( ! is_array( $settings ) ) {
+            $settings = [];
+        }
+
+        $defaults = Satori_Audit_Plugin::get_default_settings();
+
+        $sanitized = [];
+
+        foreach ( $defaults as $key => $value ) {
+            $sanitized[ $key ] = isset( $settings[ $key ] ) ? sanitize_text_field( (string) $settings[ $key ] ) : $value;
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Render settings page content.
+     */
+    public function render(): void {
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'SATORI Audit – Settings', 'satori-audit' ) . '</h1>';
+        echo '<p>' . esc_html__( 'Configure service details, notifications, access control, and automation.', 'satori-audit' ) . '</p>';
+        echo '<form action="options.php" method="post">';
+
+        settings_fields( 'satori_audit_settings' );
+        do_settings_sections( 'satori_audit_settings' );
+
+        submit_button( __( 'Save Settings', 'satori-audit' ) );
+
+        echo '</form>';
+        echo '</div>';
+    }
+
+    /**
+     * Render introduction text for Service Details section.
+     */
+    public function render_service_details_intro(): void {
+        echo '<p>' . esc_html__( 'Service details fields will be added here in future iterations.', 'satori-audit' ) . '</p>';
+    }
+}

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,8 @@
+/* Placeholder styles for SATORI Audit admin screens. */
+
+.satori-audit-placeholder {
+    background: #fff;
+    border: 1px dashed #c3c4c7;
+    padding: 16px;
+    margin-top: 12px;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,4 @@
+/* Placeholder script for SATORI Audit admin screens. */
+(function () {
+    // Future admin JS will be added here.
+})();

--- a/includes/class-satori-audit-automation.php
+++ b/includes/class-satori-audit-automation.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Automation entry points.
+ *
+ * @package Satori_Audit
+ */
+
+declare( strict_types=1 );
+
+namespace Satori_Audit\Includes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Handle scheduled tasks and hooks.
+ */
+class Satori_Audit_Automation {
+    /**
+     * Cron hook name.
+     */
+    public const CRON_HOOK = 'satori_audit_generate_monthly_report';
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( self::CRON_HOOK, [ $this, 'run_scheduled_generation' ] );
+    }
+
+    /**
+     * Schedule a recurring cron event if enabled.
+     */
+    public function maybe_schedule(): void {
+        if ( wp_next_scheduled( self::CRON_HOOK ) ) {
+            return;
+        }
+
+        wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+    }
+
+    /**
+     * Placeholder for scheduled report generation.
+     */
+    public function run_scheduled_generation(): void {
+        // Placeholder: trigger report generation for current period.
+    }
+}

--- a/includes/class-satori-audit-cpt.php
+++ b/includes/class-satori-audit-cpt.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Custom post type registration for reports.
+ *
+ * @package Satori_Audit
+ */
+
+declare( strict_types=1 );
+
+namespace Satori_Audit\Includes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Handle registration of the audit report CPT.
+ */
+class Satori_Audit_Cpt {
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( 'satori_audit_load_custom_post_types', [ $this, 'register_report_cpt' ] );
+    }
+
+    /**
+     * Register the audit report custom post type.
+     */
+    public function register_report_cpt(): void {
+        $labels = [
+            'name'               => _x( 'Audit Reports', 'post type general name', 'satori-audit' ),
+            'singular_name'      => _x( 'Audit Report', 'post type singular name', 'satori-audit' ),
+            'menu_name'          => _x( 'Audit Reports', 'admin menu', 'satori-audit' ),
+            'name_admin_bar'     => _x( 'Audit Report', 'add new on admin bar', 'satori-audit' ),
+            'add_new'            => _x( 'Add New', 'audit report', 'satori-audit' ),
+            'add_new_item'       => __( 'Add New Audit Report', 'satori-audit' ),
+            'new_item'           => __( 'New Audit Report', 'satori-audit' ),
+            'edit_item'          => __( 'Edit Audit Report', 'satori-audit' ),
+            'view_item'          => __( 'View Audit Report', 'satori-audit' ),
+            'all_items'          => __( 'All Audit Reports', 'satori-audit' ),
+            'search_items'       => __( 'Search Audit Reports', 'satori-audit' ),
+            'not_found'          => __( 'No audit reports found.', 'satori-audit' ),
+            'not_found_in_trash' => __( 'No audit reports found in Trash.', 'satori-audit' ),
+        ];
+
+        $args = [
+            'labels'              => $labels,
+            'public'              => false,
+            'show_ui'             => true,
+            'show_in_menu'        => false,
+            'capability_type'     => 'post',
+            'supports'            => [ 'title', 'editor', 'custom-fields' ],
+            'rewrite'             => false,
+            'map_meta_cap'        => true,
+            'exclude_from_search' => true,
+        ];
+
+        register_post_type( 'satori_audit_report', $args );
+    }
+}

--- a/includes/class-satori-audit-logger.php
+++ b/includes/class-satori-audit-logger.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Logging helper.
+ *
+ * @package Satori_Audit
+ */
+
+declare( strict_types=1 );
+
+namespace Satori_Audit\Includes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Basic logger wrapper for future expansion.
+ */
+class Satori_Audit_Logger {
+    /**
+     * Write a message to the WordPress debug log.
+     *
+     * @param string $message Message to log.
+     * @param array  $context Optional context data.
+     */
+    public static function log( string $message, array $context = [] ): void {
+        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+            $line = $context ? sprintf( '%s %s', $message, wp_json_encode( $context ) ) : $message;
+            error_log( '[SATORI Audit] ' . $line );
+        }
+    }
+}
+
+if ( ! function_exists( 'satori_audit_log' ) ) {
+    /**
+     * Helper function for logging.
+     *
+     * @param string $message Message to log.
+     * @param array  $context Optional context data.
+     */
+    function satori_audit_log( string $message, array $context = [] ): void {
+        Satori_Audit_Logger::log( $message, $context );
+    }
+}

--- a/includes/class-satori-audit-pdf.php
+++ b/includes/class-satori-audit-pdf.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * PDF export placeholder.
+ *
+ * @package Satori_Audit
+ */
+
+declare( strict_types=1 );
+
+namespace Satori_Audit\Includes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Handle PDF rendering and diagnostics stubs.
+ */
+class Satori_Audit_Pdf {
+    /**
+     * Render a PDF for the given report.
+     *
+     * @param int $report_id Report post ID.
+     */
+    public function render_pdf( int $report_id ): void {
+        do_action( 'satori_audit_before_render_pdf', $report_id );
+
+        // Placeholder for PDF generation implementation.
+
+        do_action( 'satori_audit_after_render_pdf', $report_id );
+    }
+
+    /**
+     * Return diagnostic info about the PDF engine.
+     *
+     * @return array
+     */
+    public function get_diagnostics(): array {
+        return [
+            'engine'   => 'pending',
+            'status'   => 'unconfigured',
+            'messages' => [ __( 'PDF engine diagnostics will be displayed here.', 'satori-audit' ) ],
+        ];
+    }
+}

--- a/includes/class-satori-audit-plugin.php
+++ b/includes/class-satori-audit-plugin.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Satori_Audit\Includes;
 
+use Satori_Audit\Admin\Satori_Audit_Admin;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
@@ -39,6 +41,13 @@ class Satori_Audit_Plugin {
      * Hook into WordPress on construction.
      */
     private function __construct() {
+        new Satori_Audit_Cpt();
+        new Satori_Audit_Tables();
+        new Satori_Audit_Admin();
+        new Satori_Audit_Reports();
+        new Satori_Audit_Plugins_Service();
+        new Satori_Audit_Automation();
+
         add_action( 'plugins_loaded', [ $this, 'load_textdomain' ] );
         add_action( 'init', [ $this, 'register_custom_post_types' ] );
         add_action( 'init', [ $this, 'register_database_tables' ] );
@@ -79,5 +88,41 @@ class Satori_Audit_Plugin {
      */
     public function register_settings(): void {
         do_action( 'satori_audit_register_settings' );
+    }
+
+    /**
+     * Activation callback.
+     */
+    public static function activate(): void {
+        Satori_Audit_Tables::activate();
+        update_option( 'satori_audit_settings', self::get_default_settings() );
+    }
+
+    /**
+     * Retrieve stored settings with defaults.
+     *
+     * @return array
+     */
+    public static function get_settings(): array {
+        $saved    = get_option( 'satori_audit_settings', [] );
+        $defaults = self::get_default_settings();
+
+        return wp_parse_args( $saved, $defaults );
+    }
+
+    /**
+     * Default settings structure.
+     *
+     * @return array
+     */
+    public static function get_default_settings(): array {
+        return [
+            'client_name'     => '',
+            'site_name'       => '',
+            'site_url'        => '',
+            'managed_by'      => '',
+            'technician_name' => '',
+            'technician_email' => '',
+        ];
     }
 }

--- a/includes/class-satori-audit-plugins-service.php
+++ b/includes/class-satori-audit-plugins-service.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Plugin inventory service placeholder.
+ *
+ * @package Satori_Audit
+ */
+
+declare( strict_types=1 );
+
+namespace Satori_Audit\Includes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Provide helpers for reading and diffing plugin state.
+ */
+class Satori_Audit_Plugins_Service {
+    /**
+     * Retrieve the current plugins installed on the site.
+     *
+     * @return array
+     */
+    public function get_current_plugins(): array {
+        if ( ! function_exists( 'get_plugins' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+
+        return get_plugins();
+    }
+
+    /**
+     * Diff two plugin lists and return change flags.
+     *
+     * @param array $current Current plugins keyed by slug.
+     * @param array $previous Previous plugins keyed by slug.
+     *
+     * @return array
+     */
+    public function diff_plugins( array $current, array $previous ): array {
+        $diff = [
+            'new'       => [],
+            'updated'   => [],
+            'deleted'   => [],
+            'unchanged' => [],
+        ];
+
+        foreach ( $current as $slug => $data ) {
+            if ( ! isset( $previous[ $slug ] ) ) {
+                $diff['new'][ $slug ] = $data;
+                continue;
+            }
+
+            $previous_version = $previous[ $slug ]['Version'] ?? '';
+            $current_version  = $data['Version'] ?? '';
+
+            if ( $previous_version !== $current_version ) {
+                $diff['updated'][ $slug ] = [
+                    'from' => $previous_version,
+                    'to'   => $current_version,
+                ];
+            } else {
+                $diff['unchanged'][ $slug ] = $data;
+            }
+        }
+
+        foreach ( array_diff_key( $previous, $current ) as $slug => $data ) {
+            $diff['deleted'][ $slug ] = $data;
+        }
+
+        return $diff;
+    }
+}

--- a/includes/class-satori-audit-reports.php
+++ b/includes/class-satori-audit-reports.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Report generation and retrieval services.
+ *
+ * @package Satori_Audit
+ */
+
+declare( strict_types=1 );
+
+namespace Satori_Audit\Includes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Provide report lifecycle helpers.
+ */
+class Satori_Audit_Reports {
+    /**
+     * Generate or refresh a report for the given period key.
+     *
+     * @param string|null $period Period key (YYYY-MM). Defaults to current month.
+     */
+    public function generate_report( ?string $period = null ): void {
+        $period = $period ?: gmdate( 'Y-m' );
+
+        do_action( 'satori_audit_before_generate_report', $period );
+
+        // Placeholder: create or update report post and associated rows.
+
+        do_action( 'satori_audit_after_generate_report', $period );
+    }
+
+    /**
+     * Lock a report to prevent further edits.
+     *
+     * @param int $report_id Report post ID.
+     */
+    public function lock_report( int $report_id ): void {
+        update_post_meta( $report_id, '_satori_audit_locked', true );
+    }
+
+    /**
+     * Unlock a report for editing.
+     *
+     * @param int $report_id Report post ID.
+     */
+    public function unlock_report( int $report_id ): void {
+        delete_post_meta( $report_id, '_satori_audit_locked' );
+    }
+
+    /**
+     * Retrieve a report by period.
+     *
+     * @param string $period Period key (YYYY-MM).
+     *
+     * @return int|null
+     */
+    public function get_report_id_by_period( string $period ): ?int {
+        $query = new \WP_Query(
+            [
+                'post_type'      => 'satori_audit_report',
+                'posts_per_page' => 1,
+                'post_status'    => 'any',
+                'meta_key'       => '_satori_audit_period',
+                'meta_value'     => $period,
+                'fields'         => 'ids',
+            ]
+        );
+
+        return $query->have_posts() ? (int) $query->posts[0] : null;
+    }
+}

--- a/includes/class-satori-audit-tables.php
+++ b/includes/class-satori-audit-tables.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Database table scaffolding.
+ *
+ * @package Satori_Audit
+ */
+
+declare( strict_types=1 );
+
+namespace Satori_Audit\Includes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Handle database table registration and activation hooks.
+ */
+class Satori_Audit_Tables {
+    /**
+     * Database schema version.
+     */
+    public const DB_VERSION = '0.0.1';
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( 'satori_audit_register_tables', [ $this, 'register_table_names' ] );
+    }
+
+    /**
+     * Map custom table names onto the $wpdb instance.
+     */
+    public function register_table_names(): void {
+        global $wpdb;
+
+        $wpdb->satori_audit_plugins  = $wpdb->prefix . 'satori_audit_plugins';
+        $wpdb->satori_audit_security = $wpdb->prefix . 'satori_audit_security';
+    }
+
+    /**
+     * Activation routine to create or update database tables.
+     */
+    public static function activate(): void {
+        self::maybe_create_tables();
+        update_option( 'satori_audit_db_version', self::DB_VERSION );
+    }
+
+    /**
+     * Placeholder for dbDelta-based table creation.
+     */
+    private static function maybe_create_tables(): void {
+        global $wpdb;
+
+        $charset_collate = $wpdb->get_charset_collate();
+
+        $plugin_table_sql  = "CREATE TABLE {$wpdb->prefix}satori_audit_plugins (\n" .
+            'id bigint(20) unsigned NOT NULL AUTO_INCREMENT,' .
+            'report_id bigint(20) unsigned NOT NULL,' .
+            'plugin_slug varchar(191) NOT NULL,' .
+            'plugin_name varchar(191) NOT NULL,' .
+            'plugin_description text NULL,' .
+            'plugin_type varchar(50) NULL,' .
+            'version_from varchar(50) NULL,' .
+            'version_to varchar(50) NULL,' .
+            'version_current varchar(50) NULL,' .
+            'is_active tinyint(1) DEFAULT 0,' .
+            'status_flag varchar(20) NOT NULL,' .
+            'price_notes text NULL,' .
+            'comments text NULL,' .
+            'last_checked datetime NULL,' .
+            'PRIMARY KEY  (id),' .
+            'KEY report_id (report_id),' .
+            'KEY plugin_slug (plugin_slug)' .
+            " ) {$charset_collate};";
+
+        $security_table_sql = "CREATE TABLE {$wpdb->prefix}satori_audit_security (\n" .
+            'id bigint(20) unsigned NOT NULL AUTO_INCREMENT,' .
+            'report_id bigint(20) unsigned NOT NULL,' .
+            'vulnerability_type varchar(191) NULL,' .
+            'description text NULL,' .
+            'cvss_score varchar(50) NULL,' .
+            'severity varchar(50) NULL,' .
+            'attack_report text NULL,' .
+            'solution text NULL,' .
+            'comments text NULL,' .
+            'action_required tinyint(1) DEFAULT 0,' .
+            'PRIMARY KEY  (id),' .
+            'KEY report_id (report_id)' .
+            " ) {$charset_collate};";
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta( [ $plugin_table_sql, $security_table_sql ] );
+    }
+}

--- a/languages/satori-audit.pot
+++ b/languages/satori-audit.pot
@@ -1,0 +1,5 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: SATORI Audit 0.0.1-dev\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: \n"

--- a/satori-audit.php
+++ b/satori-audit.php
@@ -12,7 +12,7 @@
 declare( strict_types=1 );
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+    exit;
 }
 
 /**
@@ -67,6 +67,15 @@ function satori_audit_autoload( string $class ): void {
 }
 
 spl_autoload_register( 'satori_audit_autoload' );
+
+register_activation_hook(
+    SATORI_AUDIT_PLUGIN_FILE,
+    static function (): void {
+        if ( class_exists( '\\Satori_Audit\\Includes\\Satori_Audit_Plugin' ) ) {
+            \Satori_Audit\Includes\Satori_Audit_Plugin::activate();
+        }
+    }
+);
 
 /**
  * Add an admin notice for environment issues.

--- a/templates/admin/report-preview.php
+++ b/templates/admin/report-preview.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Admin report preview placeholder template.
+ *
+ * @package Satori_Audit
+ */
+?>
+<div class="satori-audit-report-preview">
+    <p><?php esc_html_e( 'A BALL-style report preview will be rendered here.', 'satori-audit' ); ?></p>
+</div>


### PR DESCRIPTION
## Summary
- add core scaffolding classes for CPT registration, tables, reports, logging, automation, and settings defaults
- wire admin menus with placeholder dashboard, archive, and settings screens plus asset/template stubs
- register activation hook and settings skeleton to align with initial SATORI Audit spec

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692000bfa22c832d8e6a0b43f492879a)