### PR TITLE
Implement full SATORI audit build

### DIFF
--- a/admin/screens/class-satori-audit-screen-archive.php
+++ b/admin/screens/class-satori-audit-screen-archive.php
@@ -9,6 +9,9 @@ declare( strict_types=1 );
 
 namespace Satori_Audit\Admin\Screens;
 
+use Satori_Audit\Includes\Satori_Audit_Plugin;
+use WP_Query;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
@@ -18,13 +21,69 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Satori_Audit_Screen_Archive {
     /**
-     * Display placeholder archive content.
+     * Display archive content.
      */
     public function render(): void {
-        echo '<div class="wrap">';
+        $period_filter = isset( $_GET['period'] ) ? sanitize_text_field( wp_unslash( $_GET['period'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $query_args    = [
+            'post_type'      => 'satori_audit_report',
+            'posts_per_page' => 20,
+            'post_status'    => 'any',
+            'orderby'        => 'meta_value',
+            'order'          => 'DESC',
+            'meta_key'       => '_satori_audit_period',
+        ];
+
+        if ( $period_filter ) {
+            $query_args['meta_query'] = [
+                [
+                    'key'   => '_satori_audit_period',
+                    'value' => $period_filter,
+                ],
+            ];
+        }
+
+        $query = new WP_Query( $query_args );
+
+        echo '<div class="wrap satori-audit-wrap">';
         echo '<h1>' . esc_html__( 'SATORI Audit – Archive', 'satori-audit' ) . '</h1>';
-        echo '<p>' . esc_html__( 'A sortable archive of monthly reports will appear here.', 'satori-audit' ) . '</p>';
-        echo '<div class="satori-audit-placeholder">' . esc_html__( 'Archive list table coming soon.', 'satori-audit' ) . '</div>';
+        echo '<form method="get" class="satori-audit-toolbar">';
+        echo '<input type="hidden" name="page" value="satori-audit-archive" />';
+        echo '<label>' . esc_html__( 'Filter by period (YYYY-MM)', 'satori-audit' ) . '</label> ';
+        echo '<input type="text" name="period" value="' . esc_attr( $period_filter ) . '" /> ';
+        submit_button( __( 'Filter', 'satori-audit' ), 'secondary', '', false );
+        echo '</form>';
+
+        echo '<table class="widefat striped satori-audit-table">';
+        echo '<thead><tr>';
+        $headers = [ 'Period', 'Title', 'Status', 'Summary', 'Actions' ];
+        foreach ( $headers as $header ) {
+            echo '<th>' . esc_html( $header ) . '</th>';
+        }
+        echo '</tr></thead><tbody>';
+
+        if ( $query->have_posts() ) {
+            while ( $query->have_posts() ) {
+                $query->the_post();
+                $period  = get_post_meta( get_the_ID(), '_satori_audit_period', true );
+                $summary = get_post_meta( get_the_ID(), '_satori_audit_summary', true );
+                $locked  = get_post_meta( get_the_ID(), '_satori_audit_locked', true );
+                $summary_text = is_array( $summary ) ? sprintf( __( '%1$d new, %2$d updated, %3$d deleted', 'satori-audit' ), $summary['new'] ?? 0, $summary['updated'] ?? 0, $summary['deleted'] ?? 0 ) : '';
+
+                echo '<tr>';
+                echo '<td>' . esc_html( $period ) . '</td>';
+                echo '<td>' . esc_html( get_the_title() ) . '</td>';
+                echo '<td>' . ( $locked ? esc_html__( 'Locked', 'satori-audit' ) : esc_html__( 'Open', 'satori-audit' ) ) . '</td>';
+                echo '<td>' . esc_html( $summary_text ) . '</td>';
+                echo '<td><a class="button" href="' . esc_url( admin_url( 'admin.php?page=satori-audit&period=' . urlencode( $period ) ) ) . '">' . esc_html__( 'Open', 'satori-audit' ) . '</a></td>';
+                echo '</tr>';
+            }
+            wp_reset_postdata();
+        } else {
+            echo '<tr><td colspan="5" class="empty">' . esc_html__( 'No reports found.', 'satori-audit' ) . '</td></tr>';
+        }
+
+        echo '</tbody></table>';
         echo '</div>';
     }
 }

--- a/admin/screens/class-satori-audit-screen-dashboard.php
+++ b/admin/screens/class-satori-audit-screen-dashboard.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace Satori_Audit\Admin\Screens;
 
+use Satori_Audit\Includes\Satori_Audit_Plugin;
+use Satori_Audit\Includes\Satori_Audit_Pdf;
+use Satori_Audit\Includes\Satori_Audit_Reports;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
@@ -18,13 +22,422 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Satori_Audit_Screen_Dashboard {
     /**
-     * Display placeholder dashboard content.
+     * Report service.
+     */
+    private Satori_Audit_Reports $reports;
+
+    /**
+     * Constructor wires admin-post actions.
+     */
+    public function __construct() {
+        $this->reports = new Satori_Audit_Reports();
+
+        add_action( 'admin_post_satori_audit_generate_report', [ $this, 'handle_generate' ] );
+        add_action( 'admin_post_satori_audit_save_report', [ $this, 'handle_save_report' ] );
+        add_action( 'admin_post_satori_audit_export_csv', [ $this, 'handle_export_csv' ] );
+        add_action( 'admin_post_satori_audit_export_pdf', [ $this, 'handle_export_pdf' ] );
+        add_action( 'admin_post_satori_audit_lock_report', [ $this, 'handle_lock' ] );
+        add_action( 'admin_post_satori_audit_unlock_report', [ $this, 'handle_unlock' ] );
+    }
+
+    /**
+     * Display dashboard content.
      */
     public function render(): void {
-        echo '<div class="wrap">';
+        $settings = Satori_Audit_Plugin::get_settings();
+        $period   = isset( $_GET['period'] ) ? sanitize_text_field( wp_unslash( $_GET['period'] ) ) : gmdate( 'Y-m' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $report   = $this->reports->get_report_id_by_period( $period );
+
+        if ( ! $report ) {
+            $report = $this->reports->generate_report( $period );
+        }
+
+        $plugin_rows   = $this->reports->get_plugin_rows( $report );
+        $security_rows = $this->reports->get_security_rows( $report );
+        $meta          = $this->reports->get_report_meta( $report );
+        $summary       = $this->reports->get_summary( $report );
+        $locked        = $this->reports->is_locked( $report );
+
+        echo '<div class="wrap satori-audit-wrap">';
         echo '<h1>' . esc_html__( 'SATORI Audit – Dashboard', 'satori-audit' ) . '</h1>';
-        echo '<p>' . esc_html__( 'This screen will show the current period report, generation controls, and quick exports.', 'satori-audit' ) . '</p>';
-        echo '<div class="satori-audit-placeholder">' . esc_html__( 'Dashboard widgets and report preview coming soon.', 'satori-audit' ) . '</div>';
+        $this->render_toolbar( $period, $report, $locked );
+        echo '<div class="satori-audit-grid">';
+        echo '<div class="satori-audit-panel">';
+        $this->render_report_editor( $report, $period, $plugin_rows, $security_rows, $meta, $locked );
         echo '</div>';
+        echo '<div class="satori-audit-panel">';
+        $this->render_preview( $report, $period, $plugin_rows, $security_rows, $meta, $summary, $settings );
+        echo '</div>';
+        echo '</div>';
+        echo '</div>';
+    }
+
+    /**
+     * Toolbar with actions.
+     */
+    private function render_toolbar( string $period, int $report_id, bool $locked ): void {
+        $nonce = wp_create_nonce( 'satori_audit_actions' );
+
+        echo '<div class="satori-audit-toolbar">';
+        echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '">';
+        echo '<input type="hidden" name="action" value="satori_audit_generate_report" />';
+        echo '<input type="hidden" name="period" value="' . esc_attr( $period ) . '" />';
+        echo '<input type="hidden" name="_wpnonce" value="' . esc_attr( $nonce ) . '" />';
+        submit_button( __( 'Generate/Refresh Current Month', 'satori-audit' ), 'primary', 'submit', false );
+        echo '</form>';
+
+        if ( $locked ) {
+            $this->lock_button( 'unlock', __( 'Unlock', 'satori-audit' ), $period );
+        } else {
+            $this->lock_button( 'lock', __( 'Lock', 'satori-audit' ), $period );
+        }
+
+        $this->export_button( 'csv', __( 'Export CSV', 'satori-audit' ), $report_id, $period );
+        $this->export_button( 'pdf', __( 'Export PDF', 'satori-audit' ), $report_id, $period );
+        echo '</div>';
+    }
+
+    /**
+     * Helper for lock/unlock button form.
+     */
+    private function lock_button( string $action, string $label, string $period ): void {
+        $nonce = wp_create_nonce( 'satori_audit_actions' );
+        echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '">';
+        echo '<input type="hidden" name="action" value="satori_audit_' . esc_attr( $action ) . '_report" />';
+        echo '<input type="hidden" name="period" value="' . esc_attr( $period ) . '" />';
+        echo '<input type="hidden" name="_wpnonce" value="' . esc_attr( $nonce ) . '" />';
+        submit_button( $label, '', 'submit', false );
+        echo '</form>';
+    }
+
+    /**
+     * Helper for export buttons.
+     */
+    private function export_button( string $type, string $label, int $report_id, string $period ): void {
+        $nonce = wp_create_nonce( 'satori_audit_actions' );
+        echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '" target="_blank">';
+        echo '<input type="hidden" name="action" value="satori_audit_export_' . esc_attr( $type ) . '" />';
+        echo '<input type="hidden" name="report_id" value="' . esc_attr( (string) $report_id ) . '" />';
+        echo '<input type="hidden" name="period" value="' . esc_attr( $period ) . '" />';
+        echo '<input type="hidden" name="_wpnonce" value="' . esc_attr( $nonce ) . '" />';
+        submit_button( $label, 'secondary', 'submit', false );
+        echo '</form>';
+    }
+
+    /**
+     * Render report editor forms for overview, plugins, and security.
+     */
+    private function render_report_editor( int $report_id, string $period, array $plugin_rows, array $security_rows, array $meta, bool $locked ): void {
+        echo '<h2>' . esc_html__( 'Report Editor', 'satori-audit' ) . '</h2>';
+        echo '<p>' . esc_html__( 'Edit overview notes, plugin classifications, and security findings. Save to update the preview and exports.', 'satori-audit' ) . '</p>';
+        echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '" class="satori-audit-editor">';
+        wp_nonce_field( 'satori_audit_save_report', '_wpnonce' );
+        echo '<input type="hidden" name="action" value="satori_audit_save_report" />';
+        echo '<input type="hidden" name="report_id" value="' . esc_attr( (string) $report_id ) . '" />';
+        echo '<input type="hidden" name="period" value="' . esc_attr( $period ) . '" />';
+
+        if ( $locked ) {
+            echo '<p class="notice notice-warning"><em>' . esc_html__( 'This report is locked. Unlock to edit.', 'satori-audit' ) . '</em></p>';
+        }
+
+        $this->render_overview_fields( $meta );
+        $this->render_plugin_table( $plugin_rows, $locked );
+        $this->render_security_table( $security_rows, $locked );
+
+        submit_button( __( 'Save Report', 'satori-audit' ), 'primary', 'submit', false, [ 'disabled' => $locked ? 'disabled' : '' ] );
+        echo '</form>';
+    }
+
+    /**
+     * Overview text fields.
+     */
+    private function render_overview_fields( array $meta ): void {
+        $overview = $meta['overview'] ?? [ 'security' => '', 'general' => '', 'misc' => '', 'comments' => '' ];
+        echo '<div class="satori-audit-fieldset">';
+        echo '<h3>' . esc_html__( 'Overview', 'satori-audit' ) . '</h3>';
+        foreach ( $overview as $key => $value ) {
+            echo '<label>' . esc_html( ucwords( str_replace( '_', ' ', $key ) ) ) . '</label>';
+            printf( '<textarea name="overview[%1$s]" rows="2">%2$s</textarea>', esc_attr( $key ), esc_textarea( (string) $value ) );
+        }
+        echo '</div>';
+    }
+
+    /**
+     * Plugin grid table.
+     */
+    private function render_plugin_table( array $plugin_rows, bool $locked ): void {
+        echo '<div class="satori-audit-fieldset">';
+        echo '<h3>' . esc_html__( 'Plugins', 'satori-audit' ) . '</h3>';
+        echo '<table class="widefat striped satori-audit-table">';
+        echo '<thead><tr>';
+        $headers = [ 'Status', 'Slug', 'Name', 'Type', 'Version', 'From', 'To', 'Active', 'Price Notes', 'Comments' ];
+        foreach ( $headers as $header ) {
+            echo '<th>' . esc_html( $header ) . '</th>';
+        }
+        echo '</tr></thead><tbody>';
+
+        if ( empty( $plugin_rows ) ) {
+            echo '<tr><td colspan="10" class="empty">' . esc_html__( 'No plugin data captured yet.', 'satori-audit' ) . '</td></tr>';
+        } else {
+            foreach ( $plugin_rows as $index => $row ) {
+                echo '<tr>';
+                printf( '<td><input type="hidden" name="status_flag[%1$d]" value="%2$s" />%2$s</td>', $index, esc_html( $row['status_flag'] ) );
+                printf( '<td><input type="text" name="plugin_slug[%1$d]" value="%2$s" %3$s /></td>', $index, esc_attr( $row['plugin_slug'] ), disabled( $locked, true, false ) );
+                printf( '<td><input type="text" name="plugin_name[%1$d]" value="%2$s" %3$s /></td>', $index, esc_attr( $row['plugin_name'] ), disabled( $locked, true, false ) );
+                printf( '<td><input type="text" name="plugin_type[%1$d]" value="%2$s" %3$s /></td>', $index, esc_attr( $row['plugin_type'] ), disabled( $locked, true, false ) );
+                printf( '<td><input type="text" name="version_current[%1$d]" value="%2$s" %3$s /></td>', $index, esc_attr( $row['version_current'] ), disabled( $locked, true, false ) );
+                printf( '<td><input type="text" name="version_from[%1$d]" value="%2$s" %3$s /></td>', $index, esc_attr( $row['version_from'] ), disabled( $locked, true, false ) );
+                printf( '<td><input type="text" name="version_to[%1$d]" value="%2$s" %3$s /></td>', $index, esc_attr( $row['version_to'] ), disabled( $locked, true, false ) );
+                printf( '<td><input type="checkbox" name="is_active[%1$d]" %2$s %3$s /></td>', $index, checked( (int) $row['is_active'], 1, false ), disabled( $locked, true, false ) );
+                printf( '<td><textarea name="price_notes[%1$d]" %3$s>%2$s</textarea></td>', $index, esc_textarea( $row['price_notes'] ), disabled( $locked, true, false ) );
+                printf( '<td><textarea name="comments[%1$d]" %3$s>%2$s</textarea></td>', $index, esc_textarea( $row['comments'] ), disabled( $locked, true, false ) );
+                echo '<input type="hidden" name="plugin_description[' . esc_attr( (string) $index ) . ']" value="' . esc_attr( $row['plugin_description'] ) . '" />';
+                echo '<input type="hidden" name="last_checked[' . esc_attr( (string) $index ) . ']" value="' . esc_attr( $row['last_checked'] ) . '" />';
+                echo '</tr>';
+            }
+        }
+
+        // Blank row for manual additions.
+        $blank = count( $plugin_rows );
+        echo '<tr class="satori-audit-blank">';
+        echo '<td><input type="hidden" name="status_flag[' . esc_attr( (string) $blank ) . ']" value="custom" />' . esc_html__( 'Custom', 'satori-audit' ) . '</td>';
+        echo '<td><input type="text" name="plugin_slug[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . ' /></td>';
+        echo '<td><input type="text" name="plugin_name[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . ' /></td>';
+        echo '<td><input type="text" name="plugin_type[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . ' /></td>';
+        echo '<td><input type="text" name="version_current[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . ' /></td>';
+        echo '<td><input type="text" name="version_from[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . ' /></td>';
+        echo '<td><input type="text" name="version_to[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . ' /></td>';
+        echo '<td><input type="checkbox" name="is_active[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . ' /></td>';
+        echo '<td><textarea name="price_notes[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . '></textarea></td>';
+        echo '<td><textarea name="comments[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . '></textarea></td>';
+        echo '<input type="hidden" name="plugin_description[' . esc_attr( (string) $blank ) . ']" value="" />';
+        echo '<input type="hidden" name="last_checked[' . esc_attr( (string) $blank ) . ']" value="' . esc_attr( current_time( 'mysql', true ) ) . '" />';
+        echo '</tr>';
+
+        echo '</tbody></table>';
+        echo '</div>';
+    }
+
+    /**
+     * Security/known issues table.
+     */
+    private function render_security_table( array $security_rows, bool $locked ): void {
+        echo '<div class="satori-audit-fieldset">';
+        echo '<h3>' . esc_html__( 'Security & Known Issues', 'satori-audit' ) . '</h3>';
+        echo '<table class="widefat striped satori-audit-table">';
+        echo '<thead><tr>'; 
+        $headers = [ 'Type', 'Description', 'CVSS', 'Severity', 'Attack Report', 'Solution', 'Action Required' ];
+        foreach ( $headers as $header ) {
+            echo '<th>' . esc_html( $header ) . '</th>';
+        }
+        echo '</tr></thead><tbody>';
+
+        if ( empty( $security_rows ) ) {
+            echo '<tr><td colspan="7" class="empty">' . esc_html__( 'No security notes recorded yet.', 'satori-audit' ) . '</td></tr>';
+        }
+
+        foreach ( $security_rows as $index => $row ) {
+            echo '<tr>';
+            printf( '<td><input type="text" name="vulnerability_type[%1$d]" value="%2$s" %3$s /></td>', $index, esc_attr( $row['vulnerability_type'] ), disabled( $locked, true, false ) );
+            printf( '<td><textarea name="description[%1$d]" %3$s>%2$s</textarea></td>', $index, esc_textarea( $row['description'] ), disabled( $locked, true, false ) );
+            printf( '<td><input type="text" name="cvss_score[%1$d]" value="%2$s" %3$s /></td>', $index, esc_attr( $row['cvss_score'] ), disabled( $locked, true, false ) );
+            printf( '<td><input type="text" name="severity[%1$d]" value="%2$s" %3$s /></td>', $index, esc_attr( $row['severity'] ), disabled( $locked, true, false ) );
+            printf( '<td><textarea name="attack_report[%1$d]" %3$s>%2$s</textarea></td>', $index, esc_textarea( $row['attack_report'] ?? '' ), disabled( $locked, true, false ) );
+            printf( '<td><textarea name="solution[%1$d]" %3$s>%2$s</textarea></td>', $index, esc_textarea( $row['solution'] ?? '' ), disabled( $locked, true, false ) );
+            printf( '<td class="center"><input type="checkbox" name="action_required[%1$d]" %2$s %3$s /></td>', $index, checked( (int) ( $row['action_required'] ?? 0 ), 1, false ), disabled( $locked, true, false ) );
+            echo '</tr>';
+        }
+
+        $blank = count( $security_rows );
+        echo '<tr class="satori-audit-blank">';
+        echo '<td><input type="text" name="vulnerability_type[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . ' /></td>';
+        echo '<td><textarea name="description[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . '></textarea></td>';
+        echo '<td><input type="text" name="cvss_score[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . ' /></td>';
+        echo '<td><input type="text" name="severity[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . ' /></td>';
+        echo '<td><textarea name="attack_report[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . '></textarea></td>';
+        echo '<td><textarea name="solution[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . '></textarea></td>';
+        echo '<td class="center"><input type="checkbox" name="action_required[' . esc_attr( (string) $blank ) . ']" ' . disabled( $locked, true, false ) . ' /></td>';
+        echo '</tr>';
+
+        echo '</tbody></table>';
+        echo '</div>';
+    }
+
+    /**
+     * Render preview pane.
+     */
+    private function render_preview( int $report_id, string $period, array $plugin_rows, array $security_rows, array $meta, array $summary, array $settings ): void {
+        echo '<h2>' . esc_html__( 'HTML Preview', 'satori-audit' ) . '</h2>';
+        echo '<p>' . esc_html__( 'Live BALL-style preview used for PDF and CSV exports.', 'satori-audit' ) . '</p>';
+        $report_id  = $report_id; // Clarity for template include.
+        $period     = $period;
+        $plugin_rows = $plugin_rows;
+        $security_rows = $security_rows;
+        $meta        = $meta;
+        $summary     = $summary;
+        $settings    = $settings;
+
+        include SATORI_AUDIT_PLUGIN_DIR . 'templates/admin/report-preview.php';
+    }
+
+    /**
+     * Handle manual generate action.
+     */
+    public function handle_generate(): void {
+        check_admin_referer( 'satori_audit_actions' );
+        $period = isset( $_POST['period'] ) ? sanitize_text_field( wp_unslash( $_POST['period'] ) ) : gmdate( 'Y-m' );
+        $this->reports->generate_report( $period, true );
+        $this->redirect_with_notice( __( 'Report generated.', 'satori-audit' ) );
+    }
+
+    /**
+     * Handle report save.
+     */
+    public function handle_save_report(): void {
+        check_admin_referer( 'satori_audit_save_report' );
+        $report_id = isset( $_POST['report_id'] ) ? (int) $_POST['report_id'] : 0;
+        $period    = isset( $_POST['period'] ) ? sanitize_text_field( wp_unslash( $_POST['period'] ) ) : gmdate( 'Y-m' );
+
+        if ( $this->reports->is_locked( $report_id ) ) {
+            $this->redirect_with_notice( __( 'Report is locked. Unlock before saving.', 'satori-audit' ), 'error', $period );
+        }
+
+        if ( ! $report_id ) {
+            $this->redirect_with_notice( __( 'No report found.', 'satori-audit' ), 'error' );
+        }
+
+        $meta = [
+            'overview' => array_map( 'sanitize_textarea_field', $_POST['overview'] ?? [] ), // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        ];
+
+        $this->reports->save_report_meta( $report_id, $meta );
+        $this->reports->save_plugin_rows( $report_id, $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        $this->reports->save_security_rows( $report_id, $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+        $this->redirect_with_notice( __( 'Report saved.', 'satori-audit' ), 'success', $period );
+    }
+
+    /**
+     * Handle CSV export.
+     */
+    public function handle_export_csv(): void {
+        check_admin_referer( 'satori_audit_actions' );
+        $report_id = isset( $_POST['report_id'] ) ? (int) $_POST['report_id'] : 0;
+
+        if ( ! $report_id ) {
+            wp_die( esc_html__( 'Missing report.', 'satori-audit' ) );
+        }
+
+        $rows = $this->reports->get_plugin_rows( $report_id );
+        $fh   = fopen( 'php://output', 'w' );
+
+        nocache_headers();
+        header( 'Content-Type: text/csv' );
+        header( 'Content-Disposition: attachment; filename="satori-audit-' . $report_id . '.csv"' );
+
+        fputcsv( $fh, [ 'Plugin Slug', 'Plugin Name', 'Description', 'Type', 'Version From', 'Version To', 'Version Current', 'Active', 'Status', 'Price Notes', 'Comments', 'Last Checked' ] );
+
+        foreach ( $rows as $row ) {
+            fputcsv(
+                $fh,
+                [
+                    $row['plugin_slug'],
+                    $row['plugin_name'],
+                    $row['plugin_description'],
+                    $row['plugin_type'],
+                    $row['version_from'],
+                    $row['version_to'],
+                    $row['version_current'],
+                    $row['is_active'] ? 'Yes' : 'No',
+                    $row['status_flag'],
+                    $row['price_notes'],
+                    $row['comments'],
+                    $row['last_checked'],
+                ]
+            );
+        }
+
+        exit;
+    }
+
+    /**
+     * Handle PDF export.
+     */
+    public function handle_export_pdf(): void {
+        check_admin_referer( 'satori_audit_actions' );
+        $report_id = isset( $_POST['report_id'] ) ? (int) $_POST['report_id'] : 0;
+
+        if ( ! $report_id ) {
+            wp_die( esc_html__( 'Missing report.', 'satori-audit' ) );
+        }
+
+        $html = $this->capture_preview_html( $report_id );
+        ( new Satori_Audit_Pdf() )->render_pdf( $report_id, $html );
+    }
+
+    /**
+     * Render lock action.
+     */
+    public function handle_lock(): void {
+        check_admin_referer( 'satori_audit_actions' );
+        $period    = isset( $_POST['period'] ) ? sanitize_text_field( wp_unslash( $_POST['period'] ) ) : gmdate( 'Y-m' );
+        $report_id = $this->reports->get_report_id_by_period( $period );
+
+        if ( $report_id ) {
+            $this->reports->lock_report( $report_id );
+        }
+
+        $this->redirect_with_notice( __( 'Report locked.', 'satori-audit' ), 'success', $period );
+    }
+
+    /**
+     * Render unlock action.
+     */
+    public function handle_unlock(): void {
+        check_admin_referer( 'satori_audit_actions' );
+        $period    = isset( $_POST['period'] ) ? sanitize_text_field( wp_unslash( $_POST['period'] ) ) : gmdate( 'Y-m' );
+        $report_id = $this->reports->get_report_id_by_period( $period );
+
+        if ( $report_id ) {
+            $this->reports->unlock_report( $report_id );
+        }
+
+        $this->redirect_with_notice( __( 'Report unlocked.', 'satori-audit' ), 'success', $period );
+    }
+
+    /**
+     * Capture preview HTML for PDF export.
+     */
+    private function capture_preview_html( int $report_id ): string {
+        $report_service = new Satori_Audit_Reports();
+        $settings       = Satori_Audit_Plugin::get_settings();
+        $plugin_rows    = $report_service->get_plugin_rows( $report_id );
+        $security_rows  = $report_service->get_security_rows( $report_id );
+        $meta           = $report_service->get_report_meta( $report_id );
+        $summary        = $report_service->get_summary( $report_id );
+        $period         = get_post_meta( $report_id, '_satori_audit_period', true );
+
+        ob_start();
+        include SATORI_AUDIT_PLUGIN_DIR . 'templates/admin/report-preview.php';
+
+        return (string) ob_get_clean();
+    }
+
+    /**
+     * Redirect with notice message.
+     */
+    private function redirect_with_notice( string $message, string $type = 'success', string $period = '' ): void {
+        $args = [
+            'page'                => 'satori-audit',
+            'satori_audit_notice' => $message,
+            'type'                => 'success' === $type ? 'updated' : 'error',
+        ];
+
+        if ( $period ) {
+            $args['period'] = $period;
+        }
+
+        wp_safe_redirect( add_query_arg( $args, admin_url( 'admin.php' ) ) );
+        exit;
     }
 }

--- a/admin/screens/class-satori-audit-screen-settings.php
+++ b/admin/screens/class-satori-audit-screen-settings.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace Satori_Audit\Admin\Screens;
 
 use Satori_Audit\Includes\Satori_Audit_Plugin;
+use Satori_Audit\Includes\Satori_Audit_Pdf;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -27,38 +28,57 @@ class Satori_Audit_Screen_Settings {
     }
 
     /**
-     * Register a placeholder settings group and sections.
+     * Register settings, sections, and fields.
      */
     public function register_settings(): void {
         register_setting( 'satori_audit_settings', 'satori_audit_settings', [ $this, 'sanitize_settings' ] );
 
-        add_settings_section(
-            'satori_audit_service_details',
-            __( 'Service Details', 'satori-audit' ),
-            [ $this, 'render_service_details_intro' ],
-            'satori_audit_settings'
-        );
+        $tabs = [
+            'service'      => __( 'Service Details', 'satori-audit' ),
+            'notifications'=> __( 'Notifications', 'satori-audit' ),
+            'safelist'     => __( 'Safelist', 'satori-audit' ),
+            'access'       => __( 'Access Control', 'satori-audit' ),
+            'automation'   => __( 'Automation', 'satori-audit' ),
+            'display'      => __( 'Display & Output', 'satori-audit' ),
+            'pdf'          => __( 'PDF Diagnostics', 'satori-audit' ),
+        ];
+
+        foreach ( $tabs as $tab => $label ) {
+            add_settings_section( 'satori_audit_' . $tab, $label, '__return_false', 'satori_audit_settings_' . $tab );
+        }
+
+        $this->add_service_fields();
+        $this->add_notification_fields();
+        $this->add_safelist_fields();
+        $this->add_access_fields();
+        $this->add_automation_fields();
+        $this->add_display_fields();
+        $this->add_pdf_fields();
     }
 
     /**
      * Sanitize settings before saving.
      *
      * @param mixed $settings Submitted settings.
-     *
-     * @return array
      */
     public function sanitize_settings( $settings ): array {
         if ( ! is_array( $settings ) ) {
             $settings = [];
         }
 
-        $defaults = Satori_Audit_Plugin::get_default_settings();
-
+        $defaults  = Satori_Audit_Plugin::get_default_settings();
         $sanitized = [];
 
-        foreach ( $defaults as $key => $value ) {
-            $sanitized[ $key ] = isset( $settings[ $key ] ) ? sanitize_text_field( (string) $settings[ $key ] ) : $value;
+        foreach ( $defaults as $key => $default ) {
+            $value            = $settings[ $key ] ?? $default;
+            $sanitized[ $key ] = is_numeric( $value ) ? (string) $value : sanitize_text_field( (string) $value );
         }
+
+        $sanitized['suppress_wp_emails'] = empty( $settings['suppress_wp_emails'] ) ? 0 : 1;
+        $sanitized['enforce_safelist']   = empty( $settings['enforce_safelist'] ) ? 0 : 1;
+        $sanitized['enable_cron']        = empty( $settings['enable_cron'] ) ? 0 : 1;
+        $sanitized['show_security']      = empty( $settings['show_security'] ) ? 0 : 1;
+        $sanitized['show_known_issues']  = empty( $settings['show_known_issues'] ) ? 0 : 1;
 
         return $sanitized;
     }
@@ -67,24 +87,153 @@ class Satori_Audit_Screen_Settings {
      * Render settings page content.
      */
     public function render(): void {
-        echo '<div class="wrap">';
+        $active_tab = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : 'service'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $tabs       = [
+            'service'      => __( 'Service Details', 'satori-audit' ),
+            'notifications'=> __( 'Notifications', 'satori-audit' ),
+            'safelist'     => __( 'Safelist', 'satori-audit' ),
+            'access'       => __( 'Access Control', 'satori-audit' ),
+            'automation'   => __( 'Automation', 'satori-audit' ),
+            'display'      => __( 'Display & Output', 'satori-audit' ),
+            'pdf'          => __( 'PDF Diagnostics', 'satori-audit' ),
+        ];
+
+        echo '<div class="wrap satori-audit-wrap">';
         echo '<h1>' . esc_html__( 'SATORI Audit – Settings', 'satori-audit' ) . '</h1>';
-        echo '<p>' . esc_html__( 'Configure service details, notifications, access control, and automation.', 'satori-audit' ) . '</p>';
-        echo '<form action="options.php" method="post">';
+        echo '<nav class="nav-tab-wrapper">';
+        foreach ( $tabs as $tab => $label ) {
+            $class = $active_tab === $tab ? 'nav-tab nav-tab-active' : 'nav-tab';
+            echo '<a class="' . esc_attr( $class ) . '" href="' . esc_url( add_query_arg( [ 'page' => 'satori-audit-settings', 'tab' => $tab ], admin_url( 'admin.php' ) ) ) . '">' . esc_html( $label ) . '</a>';
+        }
+        echo '</nav>';
 
+        echo '<form action="options.php" method="post" class="satori-audit-settings-form">';
         settings_fields( 'satori_audit_settings' );
-        do_settings_sections( 'satori_audit_settings' );
-
+        do_settings_sections( 'satori_audit_settings_' . $active_tab );
         submit_button( __( 'Save Settings', 'satori-audit' ) );
-
         echo '</form>';
+
         echo '</div>';
     }
 
     /**
-     * Render introduction text for Service Details section.
+     * Add fields for service tab.
      */
-    public function render_service_details_intro(): void {
-        echo '<p>' . esc_html__( 'Service details fields will be added here in future iterations.', 'satori-audit' ) . '</p>';
+    private function add_service_fields(): void {
+        $fields = [
+            'client_name'  => __( 'Client / Organisation', 'satori-audit' ),
+            'site_name'    => __( 'Site Name', 'satori-audit' ),
+            'site_url'     => __( 'Site URL', 'satori-audit' ),
+            'managed_by'   => __( 'Managed By', 'satori-audit' ),
+            'start_date'   => __( 'Start Date', 'satori-audit' ),
+            'service_date' => __( 'Default Service Date', 'satori-audit' ),
+            'technician_name' => __( 'Technician Name', 'satori-audit' ),
+            'technician_email' => __( 'Technician Email', 'satori-audit' ),
+            'technician_phone' => __( 'Technician Phone', 'satori-audit' ),
+            'logo_id'      => __( 'PDF Header Logo ID', 'satori-audit' ),
+        ];
+
+        foreach ( $fields as $key => $label ) {
+            add_settings_field( $key, $label, [ $this, 'render_text_field' ], 'satori_audit_settings_service', 'satori_audit_service', [ 'key' => $key ] );
+        }
+    }
+
+    /**
+     * Notification tab fields.
+     */
+    private function add_notification_fields(): void {
+        add_settings_field( 'from_email', __( 'From Email', 'satori-audit' ), [ $this, 'render_text_field' ], 'satori_audit_settings_notifications', 'satori_audit_notifications', [ 'key' => 'from_email' ] );
+        add_settings_field( 'default_recipients', __( 'Default Recipients', 'satori-audit' ), [ $this, 'render_text_field' ], 'satori_audit_settings_notifications', 'satori_audit_notifications', [ 'key' => 'default_recipients' ] );
+        add_settings_field( 'webhook_url', __( 'Webhook URL', 'satori-audit' ), [ $this, 'render_text_field' ], 'satori_audit_settings_notifications', 'satori_audit_notifications', [ 'key' => 'webhook_url' ] );
+        add_settings_field( 'suppress_wp_emails', __( 'Suppress core/plugin auto-update emails', 'satori-audit' ), [ $this, 'render_checkbox_field' ], 'satori_audit_settings_notifications', 'satori_audit_notifications', [ 'key' => 'suppress_wp_emails' ] );
+    }
+
+    /**
+     * Safelist tab fields.
+     */
+    private function add_safelist_fields(): void {
+        add_settings_field( 'enforce_safelist', __( 'Enforce safelist', 'satori-audit' ), [ $this, 'render_checkbox_field' ], 'satori_audit_settings_safelist', 'satori_audit_safelist', [ 'key' => 'enforce_safelist' ] );
+        add_settings_field( 'safelist', __( 'Allowed email addresses/domains', 'satori-audit' ), [ $this, 'render_textarea_field' ], 'satori_audit_settings_safelist', 'satori_audit_safelist', [ 'key' => 'safelist' ] );
+    }
+
+    /**
+     * Access control tab fields.
+     */
+    private function add_access_fields(): void {
+        add_settings_field( 'cap_manage', __( 'Capability to manage reports', 'satori-audit' ), [ $this, 'render_text_field' ], 'satori_audit_settings_access', 'satori_audit_access', [ 'key' => 'cap_manage' ] );
+        add_settings_field( 'cap_export', __( 'Capability to export', 'satori-audit' ), [ $this, 'render_text_field' ], 'satori_audit_settings_access', 'satori_audit_access', [ 'key' => 'cap_export' ] );
+        add_settings_field( 'cap_settings', __( 'Capability to change settings', 'satori-audit' ), [ $this, 'render_text_field' ], 'satori_audit_settings_access', 'satori_audit_access', [ 'key' => 'cap_settings' ] );
+        add_settings_field( 'admin_email', __( 'Administrator Email', 'satori-audit' ), [ $this, 'render_text_field' ], 'satori_audit_settings_access', 'satori_audit_access', [ 'key' => 'admin_email' ] );
+    }
+
+    /**
+     * Automation tab fields.
+     */
+    private function add_automation_fields(): void {
+        add_settings_field( 'enable_cron', __( 'Enable Monthly PDF Email', 'satori-audit' ), [ $this, 'render_checkbox_field' ], 'satori_audit_settings_automation', 'satori_audit_automation', [ 'key' => 'enable_cron' ] );
+        add_settings_field( 'cron_day', __( 'Day of month', 'satori-audit' ), [ $this, 'render_text_field' ], 'satori_audit_settings_automation', 'satori_audit_automation', [ 'key' => 'cron_day' ] );
+        add_settings_field( 'cron_time', __( 'Send time (HH:MM, UTC)', 'satori-audit' ), [ $this, 'render_text_field' ], 'satori_audit_settings_automation', 'satori_audit_automation', [ 'key' => 'cron_time' ] );
+        add_settings_field( 'retain_months', __( 'Retention window (months, 0 = keep all)', 'satori-audit' ), [ $this, 'render_text_field' ], 'satori_audit_settings_automation', 'satori_audit_automation', [ 'key' => 'retain_months' ] );
+    }
+
+    /**
+     * Display tab fields.
+     */
+    private function add_display_fields(): void {
+        add_settings_field( 'show_security', __( 'Show Security section', 'satori-audit' ), [ $this, 'render_checkbox_field' ], 'satori_audit_settings_display', 'satori_audit_display', [ 'key' => 'show_security' ] );
+        add_settings_field( 'show_known_issues', __( 'Show Known Issues section', 'satori-audit' ), [ $this, 'render_checkbox_field' ], 'satori_audit_settings_display', 'satori_audit_display', [ 'key' => 'show_known_issues' ] );
+        add_settings_field( 'pdf_page_size', __( 'PDF Page Size', 'satori-audit' ), [ $this, 'render_text_field' ], 'satori_audit_settings_display', 'satori_audit_display', [ 'key' => 'pdf_page_size' ] );
+        add_settings_field( 'pdf_orientation', __( 'PDF Orientation', 'satori-audit' ), [ $this, 'render_text_field' ], 'satori_audit_settings_display', 'satori_audit_display', [ 'key' => 'pdf_orientation' ] );
+        add_settings_field( 'footer_text', __( 'Footer Text', 'satori-audit' ), [ $this, 'render_text_field' ], 'satori_audit_settings_display', 'satori_audit_display', [ 'key' => 'footer_text' ] );
+    }
+
+    /**
+     * PDF tab fields.
+     */
+    private function add_pdf_fields(): void {
+        add_settings_field( 'pdf_engine', __( 'PDF Engine', 'satori-audit' ), [ $this, 'render_pdf_status' ], 'satori_audit_settings_pdf', 'satori_audit_pdf', [ 'key' => 'pdf_engine' ] );
+        add_settings_field( 'pdf_path', __( 'Engine Path', 'satori-audit' ), [ $this, 'render_text_field' ], 'satori_audit_settings_pdf', 'satori_audit_pdf', [ 'key' => 'pdf_path' ] );
+    }
+
+    /**
+     * Render simple text input.
+     */
+    public function render_text_field( array $args ): void {
+        $settings = Satori_Audit_Plugin::get_settings();
+        $key      = $args['key'];
+        printf( '<input type="text" class="regular-text" name="satori_audit_settings[%1$s]" value="%2$s" />', esc_attr( $key ), esc_attr( $settings[ $key ] ?? '' ) );
+    }
+
+    /**
+     * Render textarea.
+     */
+    public function render_textarea_field( array $args ): void {
+        $settings = Satori_Audit_Plugin::get_settings();
+        $key      = $args['key'];
+        printf( '<textarea class="large-text" rows="4" name="satori_audit_settings[%1$s]">%2$s</textarea>', esc_attr( $key ), esc_textarea( $settings[ $key ] ?? '' ) );
+    }
+
+    /**
+     * Render checkbox field.
+     */
+    public function render_checkbox_field( array $args ): void {
+        $settings = Satori_Audit_Plugin::get_settings();
+        $key      = $args['key'];
+        printf( '<label><input type="checkbox" name="satori_audit_settings[%1$s]" value="1" %2$s /> %3$s</label>', esc_attr( $key ), checked( ! empty( $settings[ $key ] ), true, false ), esc_html__( 'Enabled', 'satori-audit' ) );
+    }
+
+    /**
+     * Render PDF diagnostics field.
+     */
+    public function render_pdf_status(): void {
+        $pdf   = new Satori_Audit_Pdf();
+        $diag  = $pdf->get_diagnostics();
+        $label = sprintf( '%1$s (%2$s)', $diag['engine'], $diag['status'] );
+        echo '<p>' . esc_html( $label ) . '</p>';
+        echo '<ul class="ul-disc">';
+        foreach ( $diag['messages'] as $message ) {
+            echo '<li>' . esc_html( $message ) . '</li>';
+        }
+        echo '</ul>';
     }
 }

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,8 +1,109 @@
-/* Placeholder styles for SATORI Audit admin screens. */
+/* SATORI Audit admin styles */
+.satori-audit-wrap .satori-audit-toolbar form {
+    display: inline-block;
+    margin-right: 8px;
+}
 
-.satori-audit-placeholder {
+.satori-audit-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    margin-top: 16px;
+}
+
+.satori-audit-panel {
     background: #fff;
-    border: 1px dashed #c3c4c7;
     padding: 16px;
+    border: 1px solid #ccd0d4;
+}
+
+.satori-audit-fieldset {
+    margin-bottom: 20px;
+}
+
+.satori-audit-fieldset label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.satori-audit-fieldset textarea,
+.satori-audit-fieldset input[type="text"] {
+    width: 100%;
+}
+
+.satori-audit-table textarea {
+    width: 100%;
+}
+
+.satori-audit-table .empty {
+    text-align: center;
+    color: #666;
+}
+
+.satori-audit-table td.center {
+    text-align: center;
+}
+
+.satori-audit-preview {
+    font-family: Arial, sans-serif;
+}
+
+.satori-audit-header {
+    display: flex;
+    justify-content: space-between;
+    border-bottom: 2px solid #111;
+    padding-bottom: 12px;
+    margin-bottom: 12px;
+}
+
+.satori-audit-overview .satori-audit-columns {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+}
+
+.satori-audit-summary .satori-audit-counters {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 10px;
+}
+
+.satori-audit-summary .legend {
+    margin-top: 8px;
+    color: #555;
+}
+
+.satori-audit-preview table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+
+.satori-audit-preview th,
+.satori-audit-preview td {
+    border: 1px solid #dcdcde;
+    padding: 8px;
+    vertical-align: top;
+}
+
+.satori-audit-preview th {
+    background: #f6f7f7;
+    text-transform: uppercase;
+    font-size: 12px;
+}
+
+.satori-audit-preview .status-new { color: #1e8cbe; }
+.satori-audit-preview .status-updated { color: #d54e21; }
+.satori-audit-preview .status-deleted { color: #444; }
+.satori-audit-preview .status-unchanged { color: #46b450; }
+
+.satori-audit-preview .muted { color: #666; font-size: 12px; }
+
+.satori-audit-footer {
     margin-top: 12px;
+    text-align: center;
+    color: #444;
 }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,4 +1,14 @@
-/* Placeholder script for SATORI Audit admin screens. */
-(function () {
-    // Future admin JS will be added here.
-})();
+/* Admin helpers for SATORI Audit */
+(function ($) {
+    $(document).ready(function () {
+        $('.satori-audit-table').on('focus', '.satori-audit-blank input, .satori-audit-blank textarea', function () {
+            var $row = $(this).closest('tr');
+            if (!$row.data('expanded')) {
+                var $clone = $row.clone();
+                $clone.find('input, textarea').val('');
+                $row.removeClass('satori-audit-blank').data('expanded', true);
+                $row.after($clone);
+            }
+        });
+    });
+})(jQuery);

--- a/includes/class-satori-audit-automation.php
+++ b/includes/class-satori-audit-automation.php
@@ -27,12 +27,20 @@ class Satori_Audit_Automation {
      */
     public function __construct() {
         add_action( self::CRON_HOOK, [ $this, 'run_scheduled_generation' ] );
+        add_action( 'admin_init', [ $this, 'maybe_schedule' ] );
     }
 
     /**
      * Schedule a recurring cron event if enabled.
      */
     public function maybe_schedule(): void {
+        $settings = Satori_Audit_Plugin::get_settings();
+
+        if ( empty( $settings['enable_cron'] ) ) {
+            wp_clear_scheduled_hook( self::CRON_HOOK );
+            return;
+        }
+
         if ( wp_next_scheduled( self::CRON_HOOK ) ) {
             return;
         }
@@ -41,9 +49,63 @@ class Satori_Audit_Automation {
     }
 
     /**
-     * Placeholder for scheduled report generation.
+     * Scheduled report generation and email dispatch.
      */
     public function run_scheduled_generation(): void {
-        // Placeholder: trigger report generation for current period.
+        $settings = Satori_Audit_Plugin::get_settings();
+
+        if ( empty( $settings['enable_cron'] ) ) {
+            return;
+        }
+
+        $today = (int) gmdate( 'j' );
+        $hour  = (int) gmdate( 'H' );
+        $cron_hour = (int) substr( (string) $settings['cron_time'], 0, 2 );
+
+        if ( $today !== (int) $settings['cron_day'] || $hour !== $cron_hour ) {
+            return;
+        }
+
+        $reports   = new Satori_Audit_Reports();
+        $report_id = $reports->generate_report( gmdate( 'Y-m' ) );
+
+        if ( ! $report_id ) {
+            return;
+        }
+
+        $reports->lock_report( $report_id );
+
+        $this->email_pdf_notice( $report_id, $settings );
+    }
+
+    /**
+     * Render HTML for email/PDF use.
+     */
+    private function get_report_html( int $report_id ): string {
+        ob_start();
+        $report_service = new Satori_Audit_Reports();
+        $settings       = Satori_Audit_Plugin::get_settings();
+        $plugin_rows    = $report_service->get_plugin_rows( $report_id );
+        $security_rows  = $report_service->get_security_rows( $report_id );
+        $meta           = $report_service->get_report_meta( $report_id );
+        $summary        = $report_service->get_summary( $report_id );
+        $period         = get_post_meta( $report_id, '_satori_audit_period', true );
+
+        include SATORI_AUDIT_PLUGIN_DIR . 'templates/admin/report-preview.php';
+
+        return (string) ob_get_clean();
+    }
+
+    /**
+     * Dispatch email notice with PDF instructions.
+     */
+    private function email_pdf_notice( int $report_id, array $settings ): void {
+        if ( empty( $settings['default_recipients'] ) ) {
+            return;
+        }
+
+        $subject = sprintf( __( 'SATORI Audit report %s', 'satori-audit' ), get_post_meta( $report_id, '_satori_audit_period', true ) );
+        $body    = __( 'The monthly audit report has been generated. Visit the dashboard to download the PDF.', 'satori-audit' );
+        wp_mail( $settings['default_recipients'], $subject, $body, [ 'From: ' . $settings['from_email'] ] );
     }
 }

--- a/includes/class-satori-audit-pdf.php
+++ b/includes/class-satori-audit-pdf.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PDF export placeholder.
+ * PDF export handler.
  *
  * @package Satori_Audit
  */
@@ -9,23 +9,50 @@ declare( strict_types=1 );
 
 namespace Satori_Audit\Includes;
 
+use Dompdf\Dompdf;
+use Dompdf\Options;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
 /**
- * Handle PDF rendering and diagnostics stubs.
+ * Handle PDF rendering and diagnostics.
  */
 class Satori_Audit_Pdf {
     /**
      * Render a PDF for the given report.
      *
-     * @param int $report_id Report post ID.
+     * @param int    $report_id Report post ID.
+     * @param string $html      HTML body to render.
      */
-    public function render_pdf( int $report_id ): void {
+    public function render_pdf( int $report_id, string $html ): void {
         do_action( 'satori_audit_before_render_pdf', $report_id );
 
-        // Placeholder for PDF generation implementation.
+        $settings = Satori_Audit_Plugin::get_settings();
+        $filename = apply_filters( 'satori_audit_pdf_filename', 'satori-audit-' . $report_id . '.pdf', $report_id );
+
+        if ( class_exists( Dompdf::class ) ) {
+            $options = new Options();
+            $options->set( 'isRemoteEnabled', true );
+            $dompdf = new Dompdf( $options );
+            $dompdf->loadHtml( $html );
+            $dompdf->setPaper( $settings['pdf_page_size'] ?: 'A4', $settings['pdf_orientation'] ?: 'portrait' );
+            $dompdf->render();
+
+            $dompdf->stream( $filename, [ 'Attachment' => true ] );
+        } else {
+            // Fallback to HTML print-friendly output.
+            nocache_headers();
+            header( 'Content-Type: text/html; charset=utf-8' );
+            header( 'Content-Disposition: inline; filename=' . $filename . '.html' );
+            echo '<style>body{font-family:Arial, sans-serif;}@media print {.no-print{display:none}}</style>';
+            echo '<div class="no-print" style="padding:12px;background:#f6f7f7;border-bottom:1px solid #ccd0d4">';
+            echo esc_html__( 'PDF engine not detected. Use your browser print dialog to save as PDF.', 'satori-audit' );
+            echo '</div>';
+            echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+            exit;
+        }
 
         do_action( 'satori_audit_after_render_pdf', $report_id );
     }
@@ -36,10 +63,14 @@ class Satori_Audit_Pdf {
      * @return array
      */
     public function get_diagnostics(): array {
+        $dompdf_available = class_exists( Dompdf::class );
+
         return [
-            'engine'   => 'pending',
-            'status'   => 'unconfigured',
-            'messages' => [ __( 'PDF engine diagnostics will be displayed here.', 'satori-audit' ) ],
+            'engine'   => $dompdf_available ? 'DOMPDF' : __( 'Browser print styles', 'satori-audit' ),
+            'status'   => $dompdf_available ? __( 'ready', 'satori-audit' ) : __( 'fallback', 'satori-audit' ),
+            'messages' => $dompdf_available
+                ? [ __( 'DOMPDF detected. Exports will render server-side.', 'satori-audit' ) ]
+                : [ __( 'DOMPDF not installed. Browser print-to-PDF fallback active.', 'satori-audit' ) ],
         ];
     }
 }

--- a/includes/class-satori-audit-plugin.php
+++ b/includes/class-satori-audit-plugin.php
@@ -38,6 +38,13 @@ class Satori_Audit_Plugin {
     }
 
     /**
+     * Public init entry point for Plugin::init() requirement.
+     */
+    public static function init(): self {
+        return self::instance();
+    }
+
+    /**
      * Hook into WordPress on construction.
      */
     private function __construct() {
@@ -111,18 +118,50 @@ class Satori_Audit_Plugin {
     }
 
     /**
-     * Default settings structure.
+     * Default settings structure covering all tabs.
      *
      * @return array
      */
     public static function get_default_settings(): array {
         return [
-            'client_name'     => '',
-            'site_name'       => '',
-            'site_url'        => '',
-            'managed_by'      => '',
-            'technician_name' => '',
-            'technician_email' => '',
+            // Service Details.
+            'client_name'        => '',
+            'site_name'          => '',
+            'site_url'           => '',
+            'managed_by'         => '',
+            'start_date'         => '',
+            'service_date'       => '',
+            'technician_name'    => '',
+            'technician_email'   => '',
+            'technician_phone'   => '',
+            'logo_id'            => '',
+            // Notifications.
+            'from_email'         => get_bloginfo( 'admin_email' ),
+            'default_recipients' => '',
+            'webhook_url'        => '',
+            'suppress_wp_emails' => 0,
+            // Safelist.
+            'enforce_safelist'   => 0,
+            'safelist'           => '',
+            // Access Control.
+            'cap_manage'         => 'manage_options',
+            'cap_export'         => 'manage_options',
+            'cap_settings'       => 'manage_options',
+            'admin_email'        => get_bloginfo( 'admin_email' ),
+            // Automation.
+            'enable_cron'        => 0,
+            'cron_day'           => '1',
+            'cron_time'          => '03:00',
+            'retain_months'      => '0',
+            // Display & Output.
+            'show_security'      => 1,
+            'show_known_issues'  => 1,
+            'pdf_page_size'      => 'A4',
+            'pdf_orientation'    => 'portrait',
+            'footer_text'        => '',
+            // PDF Diagnostics.
+            'pdf_engine'         => '',
+            'pdf_path'           => '',
         ];
     }
 }

--- a/includes/class-satori-audit-reports.php
+++ b/includes/class-satori-audit-reports.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Satori_Audit\Includes;
 
+use WP_Query;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
@@ -18,18 +20,47 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Satori_Audit_Reports {
     /**
+     * Constructor to wire hooks.
+     */
+    public function __construct() {
+        add_action( 'satori_audit_before_report_generate', [ $this, 'ensure_tables_registered' ] );
+    }
+
+    /**
      * Generate or refresh a report for the given period key.
      *
      * @param string|null $period Period key (YYYY-MM). Defaults to current month.
+     * @param bool        $force  Force generation when locked.
      */
-    public function generate_report( ?string $period = null ): void {
+    public function generate_report( ?string $period = null, bool $force = false ): int {
         $period = $period ?: gmdate( 'Y-m' );
 
-        do_action( 'satori_audit_before_generate_report', $period );
+        do_action( 'satori_audit_before_report_generate', $period );
 
-        // Placeholder: create or update report post and associated rows.
+        $report_id = $this->get_report_id_by_period( $period );
 
-        do_action( 'satori_audit_after_generate_report', $period );
+        if ( $report_id && $this->is_locked( $report_id ) && ! $force ) {
+            return $report_id;
+        }
+
+        if ( ! $report_id ) {
+            $report_id = wp_insert_post(
+                [
+                    'post_type'   => 'satori_audit_report',
+                    'post_status' => 'publish',
+                    'post_title'  => sprintf( __( 'Audit Report %s', 'satori-audit' ), $period ),
+                ]
+            );
+        }
+
+        $this->store_report_period( $report_id, $period );
+        $this->sync_plugin_rows( $report_id, $period );
+        $this->initialise_meta_defaults( $report_id );
+        $this->update_summary_meta( $report_id );
+
+        do_action( 'satori_audit_after_report_generate', $report_id, $period );
+
+        return (int) $report_id;
     }
 
     /**
@@ -38,7 +69,7 @@ class Satori_Audit_Reports {
      * @param int $report_id Report post ID.
      */
     public function lock_report( int $report_id ): void {
-        update_post_meta( $report_id, '_satori_audit_locked', true );
+        update_post_meta( $report_id, '_satori_audit_locked', 1 );
     }
 
     /**
@@ -51,6 +82,15 @@ class Satori_Audit_Reports {
     }
 
     /**
+     * Determine if a report is locked.
+     *
+     * @param int $report_id Report ID.
+     */
+    public function is_locked( int $report_id ): bool {
+        return (bool) get_post_meta( $report_id, '_satori_audit_locked', true );
+    }
+
+    /**
      * Retrieve a report by period.
      *
      * @param string $period Period key (YYYY-MM).
@@ -58,7 +98,7 @@ class Satori_Audit_Reports {
      * @return int|null
      */
     public function get_report_id_by_period( string $period ): ?int {
-        $query = new \WP_Query(
+        $query = new WP_Query(
             [
                 'post_type'      => 'satori_audit_report',
                 'posts_per_page' => 1,
@@ -70,5 +110,332 @@ class Satori_Audit_Reports {
         );
 
         return $query->have_posts() ? (int) $query->posts[0] : null;
+    }
+
+    /**
+     * Retrieve the most recent report before a given period.
+     */
+    public function get_previous_report_id( string $period ): ?int {
+        $query = new WP_Query(
+            [
+                'post_type'      => 'satori_audit_report',
+                'posts_per_page' => 1,
+                'post_status'    => 'any',
+                'meta_query'     => [
+                    [
+                        'key'     => '_satori_audit_period',
+                        'value'   => $period,
+                        'compare' => '<',
+                    ],
+                ],
+                'orderby'        => 'meta_value',
+                'order'          => 'DESC',
+                'fields'         => 'ids',
+            ]
+        );
+
+        return $query->have_posts() ? (int) $query->posts[0] : null;
+    }
+
+    /**
+     * Persist plugin rows based on current inventory.
+     */
+    private function sync_plugin_rows( int $report_id, string $period ): void {
+        $service          = new Satori_Audit_Plugins_Service();
+        $current_plugins  = $service->get_current_plugins();
+        $previous_report  = $this->get_previous_report_id( $period );
+        $previous_plugins = $previous_report ? $this->get_plugin_rows_map( $previous_report ) : [];
+        $existing         = $this->get_plugin_rows_map( $report_id );
+        $diff             = $service->diff_plugins( $current_plugins, $previous_plugins );
+
+        $rows = [];
+
+        foreach ( $diff['new'] as $slug => $data ) {
+            $rows[ $slug ] = $this->build_row( $data, 'new', $existing[ $slug ] ?? [] );
+        }
+
+        foreach ( $diff['updated'] as $slug => $data ) {
+            $rows[ $slug ] = $this->build_row(
+                array_merge( $data['data'], [
+                    'version_from' => $data['from'],
+                    'version_to'   => $data['to'],
+                ] ),
+                'updated',
+                $existing[ $slug ] ?? []
+            );
+        }
+
+        foreach ( $diff['unchanged'] as $slug => $data ) {
+            $rows[ $slug ] = $this->build_row( $data, 'unchanged', $existing[ $slug ] ?? [] );
+        }
+
+        foreach ( $diff['deleted'] as $slug => $data ) {
+            $rows[ $slug ] = $this->build_row( $data, 'deleted', $existing[ $slug ] ?? [] );
+            $rows[ $slug ]['version_from'] = $data['version_current'] ?? '';
+        }
+
+        $rows = apply_filters( 'satori_audit_plugin_rows', $rows, $report_id );
+
+        $this->replace_plugin_rows( $report_id, $rows );
+    }
+
+    /**
+     * Build a plugin row payload merging manual fields.
+     */
+    private function build_row( array $data, string $status_flag, array $existing ): array {
+        $manual_fields = [ 'plugin_type', 'price_notes', 'comments' ];
+        $row           = [
+            'plugin_slug'        => $data['plugin_slug'] ?? '',
+            'plugin_name'        => $data['plugin_name'] ?? '',
+            'plugin_description' => $data['plugin_description'] ?? '',
+            'plugin_type'        => $existing['plugin_type'] ?? '',
+            'version_from'       => $data['version_from'] ?? '',
+            'version_to'         => $data['version_to'] ?? '',
+            'version_current'    => $data['version_current'] ?? '',
+            'is_active'          => (int) ( $data['is_active'] ?? 0 ),
+            'status_flag'        => $status_flag,
+            'price_notes'        => $existing['price_notes'] ?? '',
+            'comments'           => $existing['comments'] ?? '',
+            'last_checked'       => $data['last_checked'] ?? current_time( 'mysql', true ),
+        ];
+
+        foreach ( $manual_fields as $field ) {
+            if ( isset( $existing[ $field ] ) && '' !== $existing[ $field ] ) {
+                $row[ $field ] = $existing[ $field ];
+            }
+        }
+
+        return $row;
+    }
+
+    /**
+     * Insert plugin rows for a report, replacing existing.
+     */
+    private function replace_plugin_rows( int $report_id, array $rows ): void {
+        global $wpdb;
+
+        $table = Satori_Audit_Tables::table( 'plugins' );
+        $wpdb->delete( $table, [ 'report_id' => $report_id ], [ '%d' ] );
+
+        foreach ( $rows as $row ) {
+            $wpdb->insert(
+                $table,
+                array_merge( $row, [ 'report_id' => $report_id ] ),
+                [
+                    '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%d',
+                ]
+            );
+        }
+    }
+
+    /**
+     * Retrieve plugin rows keyed by slug.
+     */
+    public function get_plugin_rows_map( int $report_id ): array {
+        $rows = $this->get_plugin_rows( $report_id );
+
+        $mapped = [];
+        foreach ( $rows as $row ) {
+            $mapped[ $row['plugin_slug'] ] = $row;
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * Retrieve plugin rows for a report.
+     */
+    public function get_plugin_rows( int $report_id ): array {
+        global $wpdb;
+
+        $table = Satori_Audit_Tables::table( 'plugins' );
+
+        return $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE report_id = %d ORDER BY plugin_name ASC", $report_id ), ARRAY_A );
+    }
+
+    /**
+     * Save plugin rows from a submitted form payload.
+     */
+    public function save_plugin_rows( int $report_id, array $payload ): void {
+        $rows = [];
+
+        $count = count( $payload['plugin_slug'] ?? [] );
+
+        for ( $i = 0; $i < $count; $i++ ) {
+            $slug = sanitize_title( $payload['plugin_slug'][ $i ] ?? '' );
+
+            if ( ! $slug ) {
+                continue;
+            }
+
+            $rows[ $slug ] = [
+                'plugin_slug'        => $slug,
+                'plugin_name'        => sanitize_text_field( $payload['plugin_name'][ $i ] ?? '' ),
+                'plugin_description' => sanitize_textarea_field( $payload['plugin_description'][ $i ] ?? '' ),
+                'plugin_type'        => sanitize_text_field( $payload['plugin_type'][ $i ] ?? '' ),
+                'version_from'       => sanitize_text_field( $payload['version_from'][ $i ] ?? '' ),
+                'version_to'         => sanitize_text_field( $payload['version_to'][ $i ] ?? '' ),
+                'version_current'    => sanitize_text_field( $payload['version_current'][ $i ] ?? '' ),
+                'is_active'          => isset( $payload['is_active'][ $i ] ) ? 1 : 0,
+                'status_flag'        => sanitize_text_field( $payload['status_flag'][ $i ] ?? 'unchanged' ),
+                'price_notes'        => sanitize_textarea_field( $payload['price_notes'][ $i ] ?? '' ),
+                'comments'           => sanitize_textarea_field( $payload['comments'][ $i ] ?? '' ),
+                'last_checked'       => sanitize_text_field( $payload['last_checked'][ $i ] ?? current_time( 'mysql', true ) ),
+            ];
+        }
+
+        $this->replace_plugin_rows( $report_id, $rows );
+        $this->update_summary_meta( $report_id );
+    }
+
+    /**
+     * Save security rows from a submitted form payload.
+     */
+    public function save_security_rows( int $report_id, array $payload ): void {
+        global $wpdb;
+
+        $table = Satori_Audit_Tables::table( 'security' );
+        $wpdb->delete( $table, [ 'report_id' => $report_id ], [ '%d' ] );
+
+        $count = count( $payload['vulnerability_type'] ?? [] );
+
+        for ( $i = 0; $i < $count; $i++ ) {
+            $type = sanitize_text_field( $payload['vulnerability_type'][ $i ] ?? '' );
+            $desc = sanitize_textarea_field( $payload['description'][ $i ] ?? '' );
+
+            if ( '' === $type && '' === $desc ) {
+                continue;
+            }
+
+            $wpdb->insert(
+                $table,
+                [
+                    'report_id'          => $report_id,
+                    'vulnerability_type' => $type,
+                    'description'        => $desc,
+                    'cvss_score'         => sanitize_text_field( $payload['cvss_score'][ $i ] ?? '' ),
+                    'severity'           => sanitize_text_field( $payload['severity'][ $i ] ?? '' ),
+                    'attack_report'      => sanitize_textarea_field( $payload['attack_report'][ $i ] ?? '' ),
+                    'solution'           => sanitize_textarea_field( $payload['solution'][ $i ] ?? '' ),
+                    'comments'           => sanitize_textarea_field( $payload['comments'][ $i ] ?? '' ),
+                    'action_required'    => isset( $payload['action_required'][ $i ] ) ? 1 : 0,
+                ],
+                [ '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%d' ]
+            );
+        }
+    }
+
+    /**
+     * Fetch security rows for a report.
+     */
+    public function get_security_rows( int $report_id ): array {
+        global $wpdb;
+
+        $table = Satori_Audit_Tables::table( 'security' );
+
+        $rows = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE report_id = %d ORDER BY id ASC", $report_id ), ARRAY_A );
+
+        return apply_filters( 'satori_audit_security_rows', $rows, $report_id );
+    }
+
+    /**
+     * Store the period meta.
+     */
+    private function store_report_period( int $report_id, string $period ): void {
+        update_post_meta( $report_id, '_satori_audit_period', $period );
+    }
+
+    /**
+     * Ensure default meta exists for a report.
+     */
+    private function initialise_meta_defaults( int $report_id ): void {
+        $meta = get_post_meta( $report_id, '_satori_audit_meta', true );
+
+        if ( ! is_array( $meta ) ) {
+            $meta = [];
+        }
+
+        $defaults = [
+            'service_details' => [
+                'service_date'  => '',
+                'start_date'    => '',
+                'technician'    => '',
+                'technician_id' => '',
+            ],
+            'overview'        => [
+                'security' => '',
+                'general'  => '',
+                'misc'     => '',
+                'comments' => '',
+            ],
+            'legend'          => __( 'NEW = newly installed, UPDATED = version change, DELETED = removed since last audit.', 'satori-audit' ),
+        ];
+
+        update_post_meta( $report_id, '_satori_audit_meta', wp_parse_args( $meta, $defaults ) );
+    }
+
+    /**
+     * Retrieve report meta.
+     */
+    public function get_report_meta( int $report_id ): array {
+        $meta = get_post_meta( $report_id, '_satori_audit_meta', true );
+
+        if ( ! is_array( $meta ) ) {
+            $meta = [];
+        }
+
+        return $meta;
+    }
+
+    /**
+     * Save report meta.
+     */
+    public function save_report_meta( int $report_id, array $meta ): void {
+        update_post_meta( $report_id, '_satori_audit_meta', $meta );
+    }
+
+    /**
+     * Calculate and store summary statistics.
+     */
+    private function update_summary_meta( int $report_id ): void {
+        $rows = $this->get_plugin_rows( $report_id );
+        $meta = [
+            'new'       => 0,
+            'updated'   => 0,
+            'deleted'   => 0,
+            'unchanged' => 0,
+        ];
+
+        foreach ( $rows as $row ) {
+            $flag = $row['status_flag'] ?? 'unchanged';
+
+            if ( ! isset( $meta[ $flag ] ) ) {
+                $flag = 'unchanged';
+            }
+
+            $meta[ $flag ]++;
+        }
+
+        update_post_meta( $report_id, '_satori_audit_summary', $meta );
+    }
+
+    /**
+     * Obtain summary counts for display.
+     */
+    public function get_summary( int $report_id ): array {
+        $stored = get_post_meta( $report_id, '_satori_audit_summary', true );
+
+        if ( ! is_array( $stored ) ) {
+            $stored = [ 'new' => 0, 'updated' => 0, 'deleted' => 0, 'unchanged' => 0 ];
+        }
+
+        return $stored;
+    }
+
+    /**
+     * Ensure table names are registered prior to generation.
+     */
+    public function ensure_tables_registered(): void {
+        ( new Satori_Audit_Tables() )->register_table_names();
     }
 }

--- a/includes/class-satori-audit-tables.php
+++ b/includes/class-satori-audit-tables.php
@@ -48,7 +48,24 @@ class Satori_Audit_Tables {
     }
 
     /**
-     * Placeholder for dbDelta-based table creation.
+     * Helper returning custom table name by key.
+     *
+     * @param string $key Table key.
+     *
+     * @return string
+     */
+    public static function table( string $key ): string {
+        global $wpdb;
+
+        return match ( $key ) {
+            'plugins'  => $wpdb->prefix . 'satori_audit_plugins',
+            'security' => $wpdb->prefix . 'satori_audit_security',
+            default    => '',
+        };
+    }
+
+    /**
+     * dbDelta-based table creation.
      */
     private static function maybe_create_tables(): void {
         global $wpdb;

--- a/satori-audit.php
+++ b/satori-audit.php
@@ -126,7 +126,7 @@ function satori_audit_boot(): void {
         return;
     }
 
-    \Satori_Audit\Includes\Satori_Audit_Plugin::instance();
+    \Satori_Audit\Includes\Satori_Audit_Plugin::init();
 }
 
 if ( satori_audit_is_compatible() ) {

--- a/templates/admin/report-preview.php
+++ b/templates/admin/report-preview.php
@@ -1,10 +1,149 @@
 <?php
 /**
- * Admin report preview placeholder template.
+ * Admin report preview template.
+ *
+ * Variables expected: $report_id, $period, $plugin_rows, $security_rows, $meta, $summary, $settings.
  *
  * @package Satori_Audit
  */
+
+$settings = $settings ?? \Satori_Audit\Includes\Satori_Audit_Plugin::get_settings();
+$meta      = $meta ?? [];
+$summary   = $summary ?? [];
+$period    = $period ?? '';
+$plugin_rows  = $plugin_rows ?? [];
+$security_rows = $security_rows ?? [];
+$service_details = $settings;
+$overview  = $meta['overview'] ?? [ 'security' => '', 'general' => '', 'misc' => '', 'comments' => '' ];
 ?>
-<div class="satori-audit-report-preview">
-    <p><?php esc_html_e( 'A BALL-style report preview will be rendered here.', 'satori-audit' ); ?></p>
+<div class="satori-audit-preview">
+    <header class="satori-audit-header">
+        <div>
+            <h2><?php echo esc_html( $settings['site_name'] ?: get_bloginfo( 'name' ) ); ?></h2>
+            <p><?php echo esc_html( $settings['site_url'] ?: home_url() ); ?></p>
+            <p><?php echo esc_html( $settings['managed_by'] ); ?></p>
+        </div>
+        <div class="satori-audit-meta">
+            <p><strong><?php esc_html_e( 'Period', 'satori-audit' ); ?>:</strong> <?php echo esc_html( $period ); ?></p>
+            <p><strong><?php esc_html_e( 'Client', 'satori-audit' ); ?>:</strong> <?php echo esc_html( $settings['client_name'] ); ?></p>
+            <p><strong><?php esc_html_e( 'Technician', 'satori-audit' ); ?>:</strong> <?php echo esc_html( $service_details['technician_name'] ?? '' ); ?></p>
+        </div>
+    </header>
+
+    <section class="satori-audit-overview">
+        <h3><?php esc_html_e( 'Overview', 'satori-audit' ); ?></h3>
+        <div class="satori-audit-columns">
+            <div>
+                <h4><?php esc_html_e( 'Security', 'satori-audit' ); ?></h4>
+                <p><?php echo nl2br( esc_html( $overview['security'] ?? '' ) ); ?></p>
+            </div>
+            <div>
+                <h4><?php esc_html_e( 'General', 'satori-audit' ); ?></h4>
+                <p><?php echo nl2br( esc_html( $overview['general'] ?? '' ) ); ?></p>
+            </div>
+            <div>
+                <h4><?php esc_html_e( 'Misc', 'satori-audit' ); ?></h4>
+                <p><?php echo nl2br( esc_html( $overview['misc'] ?? '' ) ); ?></p>
+            </div>
+        </div>
+        <div>
+            <h4><?php esc_html_e( 'Comments', 'satori-audit' ); ?></h4>
+            <p><?php echo nl2br( esc_html( $overview['comments'] ?? '' ) ); ?></p>
+        </div>
+    </section>
+
+    <section class="satori-audit-summary">
+        <h3><?php esc_html_e( 'Plugin Summary', 'satori-audit' ); ?></h3>
+        <ul class="satori-audit-counters">
+            <li><?php printf( esc_html__( '%d New', 'satori-audit' ), (int) ( $summary['new'] ?? 0 ) ); ?></li>
+            <li><?php printf( esc_html__( '%d Updated', 'satori-audit' ), (int) ( $summary['updated'] ?? 0 ) ); ?></li>
+            <li><?php printf( esc_html__( '%d Deleted', 'satori-audit' ), (int) ( $summary['deleted'] ?? 0 ) ); ?></li>
+            <li><?php printf( esc_html__( '%d Unchanged', 'satori-audit' ), (int) ( $summary['unchanged'] ?? 0 ) ); ?></li>
+        </ul>
+        <p class="legend"><?php echo esc_html( $meta['legend'] ?? __( 'NEW = newly installed, UPDATED = version change, DELETED = removed since last audit.', 'satori-audit' ) ); ?></p>
+    </section>
+
+    <section class="satori-audit-plugins">
+        <h3><?php esc_html_e( 'Plugins', 'satori-audit' ); ?></h3>
+        <table>
+            <thead>
+                <tr>
+                    <th><?php esc_html_e( 'Status', 'satori-audit' ); ?></th>
+                    <th><?php esc_html_e( 'Plugin', 'satori-audit' ); ?></th>
+                    <th><?php esc_html_e( 'Version', 'satori-audit' ); ?></th>
+                    <th><?php esc_html_e( 'Active', 'satori-audit' ); ?></th>
+                    <th><?php esc_html_e( 'Type', 'satori-audit' ); ?></th>
+                    <th><?php esc_html_e( 'Notes', 'satori-audit' ); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php if ( empty( $plugin_rows ) ) : ?>
+                    <tr><td colspan="6" class="empty"><?php esc_html_e( 'No plugin data available.', 'satori-audit' ); ?></td></tr>
+                <?php else : ?>
+                    <?php foreach ( $plugin_rows as $row ) : ?>
+                        <tr>
+                            <td class="status status-<?php echo esc_attr( $row['status_flag'] ); ?>"><?php echo esc_html( strtoupper( $row['status_flag'] ) ); ?></td>
+                            <td>
+                                <strong><?php echo esc_html( $row['plugin_name'] ); ?></strong>
+                                <div class="description"><?php echo esc_html( wp_trim_words( (string) $row['plugin_description'], 20 ) ); ?></div>
+                            </td>
+                            <td>
+                                <?php echo esc_html( $row['version_current'] ); ?>
+                                <?php if ( $row['version_from'] && $row['version_to'] ) : ?>
+                                    <div class="muted"><?php printf( esc_html__( 'from %1$s to %2$s', 'satori-audit' ), esc_html( $row['version_from'] ), esc_html( $row['version_to'] ) ); ?></div>
+                                <?php endif; ?>
+                            </td>
+                            <td><?php echo $row['is_active'] ? esc_html__( 'Yes', 'satori-audit' ) : esc_html__( 'No', 'satori-audit' ); ?></td>
+                            <td><?php echo esc_html( $row['plugin_type'] ); ?></td>
+                            <td>
+                                <?php echo nl2br( esc_html( $row['price_notes'] ) ); ?>
+                                <?php if ( ! empty( $row['comments'] ) ) : ?>
+                                    <div class="muted"><?php echo nl2br( esc_html( $row['comments'] ) ); ?></div>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+            </tbody>
+        </table>
+    </section>
+
+    <?php if ( ! empty( $settings['show_security'] ) ) : ?>
+    <section class="satori-audit-security">
+        <h3><?php esc_html_e( 'Security & Known Issues', 'satori-audit' ); ?></h3>
+        <table>
+            <thead>
+                <tr>
+                    <th><?php esc_html_e( 'Type', 'satori-audit' ); ?></th>
+                    <th><?php esc_html_e( 'Description', 'satori-audit' ); ?></th>
+                    <th><?php esc_html_e( 'Severity', 'satori-audit' ); ?></th>
+                    <th><?php esc_html_e( 'Action', 'satori-audit' ); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php if ( empty( $security_rows ) ) : ?>
+                    <tr><td colspan="4" class="empty"><?php esc_html_e( 'No security findings recorded.', 'satori-audit' ); ?></td></tr>
+                <?php else : ?>
+                    <?php foreach ( $security_rows as $row ) : ?>
+                        <tr>
+                            <td><?php echo esc_html( $row['vulnerability_type'] ); ?></td>
+                            <td>
+                                <?php echo nl2br( esc_html( $row['description'] ) ); ?>
+                                <?php if ( ! empty( $row['solution'] ) ) : ?>
+                                    <div class="muted"><?php esc_html_e( 'Solution:', 'satori-audit' ); ?> <?php echo nl2br( esc_html( $row['solution'] ) ); ?></div>
+                                <?php endif; ?>
+                            </td>
+                            <td><?php echo esc_html( $row['severity'] ); ?><?php echo $row['cvss_score'] ? ' (' . esc_html( $row['cvss_score'] ) . ')' : ''; ?></td>
+                            <td><?php echo ! empty( $row['action_required'] ) ? esc_html__( 'Action required', 'satori-audit' ) : esc_html__( 'Monitor', 'satori-audit' ); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+            </tbody>
+        </table>
+    </section>
+    <?php endif; ?>
+
+    <?php if ( ! empty( $settings['footer_text'] ) ) : ?>
+        <footer class="satori-audit-footer"><?php echo esc_html( $settings['footer_text'] ); ?></footer>
+    <?php endif; ?>
 </div>


### PR DESCRIPTION
## Summary
- implement SATORI Audit core bootstrapping, CPTs, custom tables, and logging
- add report generation with plugin diffing, editable admin UI, exports, and previews
- wire settings, automation hooks, CSV/PDF exports, and BALL-style templates with styling

## Testing
- not run (WordPress environment not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920044fd6cc832d800a4a5ff67c9e0e)