### PR TITLE
Feature: Remove Simple History integration and add internal update tracking

### DIFF
--- a/admin/screens/class-satori-audit-screen-settings.php
+++ b/admin/screens/class-satori-audit-screen-settings.php
@@ -482,16 +482,12 @@ class Screen_Settings {
                         __( 'Enable verbose debug logging for SATORI Audit.', 'satori-audit' )
                 );
 
-                self::add_select_field(
-                        'plugin_update_source',
-                        __( 'Plugin Update Source (Simple History)', 'satori-audit' ),
+                self::add_checkbox_field(
+                        'track_update_history_internal',
+                        __( 'Track Update History (Internal)', 'satori-audit' ),
                         'satori_audit_section_diagnostics',
                         $pdfdiag_page,
-                        array(
-                                'none'                => __( 'Disabled', 'satori-audit' ),
-                                'simple_history_safe' => __( 'Simple History (safe)', 'satori-audit' ),
-                        ),
-                        __( 'Select whether to merge plugin updates from Simple History when schema checks pass.', 'satori-audit' )
+                        __( 'Store plugin update history in SATORI Audit without relying on third-party plugins.', 'satori-audit' )
                 );
 
                 self::add_checkbox_field(
@@ -884,12 +880,6 @@ class Screen_Settings {
                         $output['pdf_orientation'] = in_array( $value, $allowed, true ) ? $value : $current['pdf_orientation'];
                 }
 
-                if ( array_key_exists( 'plugin_update_source', $input ) ) {
-                        $allowed = array( 'none', 'simple_history_safe' );
-                        $value   = (string) $input['plugin_update_source'];
-                        $output['plugin_update_source'] = in_array( $value, $allowed, true ) ? $value : 'none';
-                }
-
                 // Checkboxes.
                 $checkboxes = array(
                         'notify_send_on_publish',
@@ -901,6 +891,7 @@ class Screen_Settings {
                         'pdf_debug_html',
                         'debug_mode',
                         'log_to_file',
+                        'track_update_history_internal',
                 );
 
                 foreach ( $checkboxes as $key ) {

--- a/includes/class-satori-audit-plugin.php
+++ b/includes/class-satori-audit-plugin.php
@@ -117,12 +117,22 @@ class Plugin {
 			Admin::init();
 		}
 
-		// Reports engine bootstrap.
+                // Reports engine bootstrap.
                 add_action(
                         'init',
                         static function () {
                                 if ( class_exists( Reports::class ) && method_exists( Reports::class, 'init' ) ) {
                                         Reports::init();
+                                }
+                        }
+                );
+
+                // Update history storage.
+                add_action(
+                        'init',
+                        static function () {
+                                if ( class_exists( Update_Storage::class ) && method_exists( Update_Storage::class, 'init' ) ) {
+                                        Update_Storage::init();
                                 }
                         }
                 );

--- a/includes/class-satori-audit-plugins-service.php
+++ b/includes/class-satori-audit-plugins-service.php
@@ -26,21 +26,39 @@ class Plugins_Service {
      */
     public static function get_plugin_update_history( int $report_id = 0 ): array {
         $settings = Settings::get_settings();
-        $range    = self::get_date_range( $report_id );
 
-        $history = self::build_fallback_history( $report_id );
+        if ( empty( $settings['track_update_history_internal'] ) ) {
+            self::log_debug( 'Plugin update history disabled via settings.' );
 
-        $simple_history_updates = self::get_updates_from_simple_history( $range, $settings );
-
-        if ( ! empty( $simple_history_updates ) ) {
-            $history = array_merge( $history, $simple_history_updates );
+            return array();
         }
+
+        $range = self::get_date_range( $report_id );
+
+        Update_Storage::maybe_migrate_recent_history();
+
+        $rows = Update_Storage::get_updates_between( $range['from'], $range['to'] );
+
+        if ( empty( $rows ) ) {
+            $rows = self::sync_recent_updates( $report_id, $range );
+        }
+
+        $history = array_map(
+            static function ( array $row ): array {
+                return array(
+                    'plugin'      => $row['plugin_name'] ?? '',
+                    'old_version' => $row['previous_version'] ?? '',
+                    'new_version' => $row['new_version'] ?? '',
+                    'date'        => $row['updated_on'] ?? '',
+                );
+            },
+            $rows
+        );
 
         self::log_debug(
             sprintf(
-                'Compiled plugin update history for report %d (Simple History mode: %s). Total records: %d.',
+                'Compiled plugin update history for report %d using internal storage. Total records: %d.',
                 $report_id,
-                $settings['plugin_update_source'] ?? 'none',
                 count( $history )
             )
         );
@@ -64,7 +82,7 @@ class Plugins_Service {
         $current_time = current_time( 'mysql', true );
 
         foreach ( $plugins as $file => $data ) {
-            $slug = $this->normalise_slug( $file );
+            $slug = self::normalise_slug( $file );
 
             $normalized[ $slug ] = [
                 'plugin_slug'        => $slug,
@@ -84,29 +102,10 @@ class Plugins_Service {
      *
      * @param string $plugin_file Plugin file path.
      */
-    private function normalise_slug( string $plugin_file ): string {
+    private static function normalise_slug( string $plugin_file ): string {
         $parts = explode( '/', $plugin_file );
 
         return sanitize_title( $parts[0] ?? $plugin_file );
-    }
-
-    /**
-     * Determine if Simple History is active.
-     */
-    private static function is_simple_history_active(): bool {
-        return class_exists( '\\Simple_History\\Simple_History' ) || class_exists( 'Simple_History' );
-    }
-
-    /**
-     * Determine if the Simple History table exists.
-     */
-    private static function simple_history_table_exists( string $table = '' ): bool {
-        global $wpdb;
-
-        $table_name = ! empty( $table ) ? $table : $wpdb->prefix . 'simple_history';
-        $found      = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
-
-        return $table_name === $found;
     }
 
     /**
@@ -144,289 +143,40 @@ class Plugins_Service {
     }
 
     /**
-     * Load plugin updates from Simple History events when enabled and schema-compatible.
+     * Derive recent updates by diffing current plugins against the previous report.
      */
-    private static function get_updates_from_simple_history( array $range, array $settings ): array {
-        if ( 'simple_history_safe' !== (string) ( $settings['plugin_update_source'] ?? 'none' ) ) {
-            return array();
-        }
-
-        global $wpdb;
-
-        if ( ! self::is_simple_history_active() ) {
-            self::log_simple_history( 'Simple History integration skipped: plugin not active.' );
-
-            return array();
-        }
-
-        $table                 = $wpdb->prefix . 'simple_history';
-        $previous_suppression  = $wpdb->suppress_errors( true );
-        $columns               = array();
-        $has_context_column    = false;
-        $selectable_columns    = array( 'date', 'message' );
-
-        if ( ! self::simple_history_table_exists( $table ) ) {
-            $wpdb->suppress_errors( $previous_suppression );
-            self::log_simple_history( 'Simple History integration skipped: table not found: ' . $table );
-
-            return array();
-        }
-
-        $columns = self::get_simple_history_columns( $table );
-
-        if ( empty( $columns ) ) {
-            $wpdb->suppress_errors( $previous_suppression );
-            self::log_simple_history( 'Simple History integration skipped: unable to read columns for ' . $table );
-
-            return array();
-        }
-
-        foreach ( array( 'date', 'message' ) as $required ) {
-            if ( ! in_array( $required, $columns, true ) ) {
-                $wpdb->suppress_errors( $previous_suppression );
-                self::log_simple_history(
-                    'Simple History integration skipped: missing column "' . $required . '" on ' . $table
-                );
-
-                return array();
-            }
-        }
-
-        $has_context_column = in_array( 'context', $columns, true );
-
-        if ( $has_context_column ) {
-            $selectable_columns[] = 'context';
-        }
-
-        $column_list = implode(
-            ', ',
-            array_filter(
-                array_map(
-                    array( self::class, 'wrap_simple_history_column' ),
-                    $selectable_columns
-                )
-            )
-        );
-
-        if ( empty( $column_list ) ) {
-            $wpdb->suppress_errors( $previous_suppression );
-            self::log_simple_history( 'Simple History integration skipped: no selectable columns available.' );
-
-            return array();
-        }
-
-        $events = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT {$column_list} FROM {$table} WHERE action IN (%s, %s, %s) AND date BETWEEN %s AND %s ORDER BY date DESC",
-                'plugin_updated',
-                'updated',
-                'plugin_update',
-                $range['from'],
-                $range['to']
-            ),
-            ARRAY_A
-        );
-
-        $wpdb->suppress_errors( $previous_suppression );
-
-        if ( null === $events ) {
-            self::log_simple_history( 'Failed to query Simple History: ' . $wpdb->last_error );
-
-            return array();
-        }
-
-        $history = array();
-
-        foreach ( $events as $event ) {
-            $normalized = self::normalize_simple_history_event( $event, $has_context_column );
-
-            if ( ! empty( $normalized ) ) {
-                $history[] = $normalized;
-            }
-        }
-
-        self::log_simple_history( sprintf( 'Loaded %d plugin update rows from Simple History.', count( $history ) ) );
-
-        return $history;
-    }
-
-    /**
-     * Retrieve available columns from the Simple History table.
-     */
-    private static function get_simple_history_columns( string $table ): array {
-        global $wpdb;
-
-        return array_map( 'strval', (array) $wpdb->get_col( "SHOW COLUMNS FROM {$table}" ) );
-    }
-
-    /**
-     * Build a safe column identifier for SELECT clauses.
-     */
-    private static function wrap_simple_history_column( string $column ): string {
-        $allowed = array( 'date', 'message', 'context' );
-
-        return in_array( $column, $allowed, true ) ? '`' . $column . '`' : '';
-    }
-
-    /**
-     * Normalize a Simple History row into the SATORI Audit structure.
-     */
-    private static function normalize_simple_history_event( array $event, bool $has_context ): array {
-        $context_data = array();
-
-        if ( $has_context && isset( $event['context'] ) ) {
-            $context_data = self::parse_simple_history_context( (string) $event['context'] );
-        }
-
-        $message_data = self::parse_simple_history_message( (string) ( $event['message'] ?? '' ) );
-
-        $plugin_name = $context_data['plugin'] ?? $context_data['plugin_name'] ?? '';
-        $old_version = $context_data['old_version'] ?? '';
-        $new_version = $context_data['new_version'] ?? '';
-
-        if ( empty( $plugin_name ) && ! empty( $context_data['plugin_slug'] ) ) {
-            $plugin_name = $context_data['plugin_slug'];
-        }
-
-        if ( empty( $plugin_name ) && ! empty( $message_data['plugin'] ) ) {
-            $plugin_name = $message_data['plugin'];
-        }
-
-        if ( empty( $old_version ) && ! empty( $message_data['old_version'] ) ) {
-            $old_version = $message_data['old_version'];
-        }
-
-        if ( empty( $new_version ) && ! empty( $message_data['new_version'] ) ) {
-            $new_version = $message_data['new_version'];
-        }
-
-        $date_value = $event['date'] ?? '';
-        $date       = '';
-
-        if ( ! empty( $date_value ) ) {
-            $timestamp = strtotime( (string) $date_value );
-
-            if ( false !== $timestamp ) {
-                $date = gmdate( 'Y-m-d H:i:s', $timestamp );
-            }
-        }
-
-        if ( empty( $plugin_name ) ) {
-            return array();
-        }
-
-        return array(
-            'plugin'      => $plugin_name,
-            'old_version' => $old_version,
-            'new_version' => $new_version,
-            'date'        => $date,
-        );
-    }
-
-    /**
-     * Parse a Simple History message column for plugin/version clues.
-     */
-    private static function parse_simple_history_message( string $message ): array {
-        if ( empty( $message ) ) {
-            return array();
-        }
-
-        $normalized = array(
-            'plugin'      => '',
-            'old_version' => '',
-            'new_version' => '',
-        );
-
-        $patterns = array(
-            '/Updated plugin\s+\"?(?P<plugin>[^\"]+)\"?\s+from version\s+(?P<old>[\w\.\-]+)\s+to\s+(?P<new>[\w\.\-]+)/i',
-            '/Plugin\s+\"?(?P<plugin>[^\"]+)\"?\s+was\s+updated\s+from\s+version\s+(?P<old>[\w\.\-]+)\s+to\s+(?P<new>[\w\.\-]+)/i',
-        );
-
-        foreach ( $patterns as $pattern ) {
-            if ( preg_match( $pattern, $message, $matches ) ) {
-                $normalized['plugin']      = $matches['plugin'] ?? '';
-                $normalized['old_version'] = $matches['old'] ?? '';
-                $normalized['new_version'] = $matches['new'] ?? '';
-                break;
-            }
-        }
-
-        return $normalized;
-    }
-
-    /**
-     * Write Simple History-specific log entries.
-     */
-    private static function log_simple_history( string $message ): void {
-        if ( function_exists( 'satori_audit_log' ) ) {
-            satori_audit_log( '[Simple History] ' . $message );
-        }
-    }
-
-    /**
-     * Parse the Simple History context payload.
-     *
-     * @param string $raw Raw context payload.
-     */
-    private static function parse_simple_history_context( string $raw ): array {
-        $decoded = json_decode( $raw, true );
-
-        if ( is_array( $decoded ) ) {
-            return self::normalize_context_keys( $decoded );
-        }
-
-        $maybe_array = maybe_unserialize( $raw );
-
-        if ( is_array( $maybe_array ) ) {
-            return self::normalize_context_keys( $maybe_array );
-        }
-
-        return array();
-    }
-
-    /**
-     * Normalise context keys across possible schemas.
-     */
-    private static function normalize_context_keys( array $context ): array {
-        $normalized = array();
-
-        $normalized['plugin_name'] = $context['plugin_name'] ?? $context['Plugin name'] ?? $context['plugin'] ?? $context['plugin_slug'] ?? '';
-        $normalized['plugin_slug'] = $context['plugin_slug'] ?? $context['plugin'] ?? '';
-        $normalized['plugin']      = $normalized['plugin_name'] ?: $normalized['plugin_slug'];
-        $normalized['old_version'] = $context['version_old'] ?? $context['plugin_version_prev'] ?? $context['old_version'] ?? '';
-        $normalized['new_version'] = $context['version_new'] ?? $context['plugin_version'] ?? $context['new_version'] ?? '';
-
-        return $normalized;
-    }
-
-    /**
-     * Build plugin update history using WordPress data when Simple History is missing.
-     */
-    private static function build_fallback_history( int $report_id ): array {
+    private static function sync_recent_updates( int $report_id, array $range ): array {
         if ( ! function_exists( 'get_plugins' ) ) {
             require_once ABSPATH . 'wp-admin/includes/plugin.php';
         }
 
-        $current_plugins  = get_plugins();
+        $current_plugins   = get_plugins();
         $previous_versions = self::get_previous_versions( $report_id );
-        $history           = array();
-        $timestamp         = current_time( 'mysql', true );
+        $timestamp         = $range['to'];
 
         foreach ( $current_plugins as $file => $data ) {
-            $slug         = sanitize_title( wp_basename( $file ) );
-            $plugin_name  = $data['Name'] ?? $slug;
-            $new_version  = $data['Version'] ?? '';
-            $old_version  = $previous_versions[ $slug ] ?? '';
+            $slug        = sanitize_title( wp_basename( (string) $file ) );
+            $plugin_name = (string) ( $data['Name'] ?? $slug );
+            $new_version = (string) ( $data['Version'] ?? '' );
+            $old_version = (string) ( $previous_versions[ $slug ] ?? '' );
 
-            $history[] = array(
-                'plugin'      => $plugin_name,
-                'old_version' => $old_version,
-                'new_version' => $new_version,
-                'date'        => $timestamp,
+            if ( empty( $old_version ) || $old_version === $new_version ) {
+                continue;
+            }
+
+            Update_Storage::record_update(
+                array(
+                    'plugin_slug'      => $slug,
+                    'plugin_name'      => $plugin_name,
+                    'previous_version' => $old_version,
+                    'new_version'      => $new_version,
+                    'updated_on'       => $timestamp,
+                    'source'           => 'auto',
+                )
             );
         }
 
-        return $history;
+        return Update_Storage::get_updates_between( $range['from'], $range['to'] );
     }
 
     /**

--- a/includes/class-satori-audit-settings.php
+++ b/includes/class-satori-audit-settings.php
@@ -79,7 +79,7 @@ class Settings {
                         'debug_mode'                     => 0,
                         'log_to_file'                    => 0,
                         'log_retention_days'             => '90',
-                        'plugin_update_source'           => 'none',
+                        'track_update_history_internal'  => 1,
                 );
         }
 

--- a/includes/class-satori-audit-tables.php
+++ b/includes/class-satori-audit-tables.php
@@ -20,7 +20,7 @@ class Tables {
     /**
      * Database schema version.
      */
-    public const DB_VERSION = '0.1.0';
+    public const DB_VERSION = '0.2.0';
 
     /**
      * Map custom table names onto the $wpdb instance.
@@ -32,6 +32,7 @@ class Tables {
 
         $wpdb->satori_audit_plugins  = $wpdb->prefix . 'satori_audit_plugins';
         $wpdb->satori_audit_security = $wpdb->prefix . 'satori_audit_security';
+        $wpdb->satori_audit_updates  = $wpdb->prefix . 'satori_audit_updates';
     }
 
     /**
@@ -76,6 +77,7 @@ class Tables {
         return match ( $key ) {
             'plugins'  => $wpdb->prefix . 'satori_audit_plugins',
             'security' => $wpdb->prefix . 'satori_audit_security',
+            'updates'  => $wpdb->prefix . 'satori_audit_updates',
             default    => '',
         };
     }
@@ -125,7 +127,22 @@ class Tables {
             ' KEY report_id (report_id)' .
             " ) {$charset_collate};";
 
+        $updates_table_sql = "CREATE TABLE {$wpdb->prefix}satori_audit_updates (\n" .
+            ' id bigint(20) unsigned NOT NULL AUTO_INCREMENT,' .
+            ' plugin_slug varchar(190) NOT NULL,' .
+            ' plugin_name varchar(255) NOT NULL,' .
+            ' previous_version varchar(50) NULL,' .
+            ' new_version varchar(50) NULL,' .
+            ' updated_on datetime NOT NULL,' .
+            " source varchar(20) NOT NULL DEFAULT 'auto'," .
+            ' created_at datetime NOT NULL,' .
+            ' updated_at datetime NOT NULL,' .
+            ' PRIMARY KEY  (id),' .
+            ' KEY plugin_slug (plugin_slug),' .
+            ' KEY updated_on (updated_on)' .
+            " ) {$charset_collate};";
+
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        dbDelta( array( $plugin_table_sql, $security_table_sql ) );
+        dbDelta( array( $plugin_table_sql, $security_table_sql, $updates_table_sql ) );
     }
 }

--- a/includes/class-satori-audit-update-storage.php
+++ b/includes/class-satori-audit-update-storage.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * Internal storage for plugin update history.
+ *
+ * @package Satori_Audit
+ */
+
+declare( strict_types=1 );
+
+namespace Satori_Audit;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Provide CRUD helpers for plugin update history rows.
+ */
+class Update_Storage {
+    /**
+     * Option key used to gate the one-time migration.
+     */
+    private const MIGRATION_OPTION = 'satori_audit_migration_done';
+
+    /**
+     * Hook runtime events.
+     */
+    public static function init(): void {
+        add_action( 'init', array( self::class, 'maybe_migrate_recent_history' ) );
+        add_action( 'upgrader_process_complete', array( self::class, 'capture_upgrader_event' ), 10, 2 );
+    }
+
+    /**
+     * Return the fully-qualified updates table name.
+     */
+    public static function table(): string {
+        Tables::register_table_names();
+
+        return Tables::table( 'updates' );
+    }
+
+    /**
+     * Insert a plugin update record when tracking is enabled.
+     *
+     * @param array{plugin_slug:string,plugin_name:string,previous_version:string,new_version:string,updated_on?:string,source?:string} $data Update payload.
+     */
+    public static function record_update( array $data ): bool {
+        global $wpdb;
+
+        $table = self::table();
+
+        if ( empty( $table ) || ! self::table_exists( $table ) ) {
+            return false;
+        }
+
+        $defaults = array(
+            'updated_on' => current_time( 'mysql', true ),
+            'source'     => 'auto',
+        );
+
+        $payload = array_merge( $defaults, $data );
+
+        $payload['updated_on'] = self::normalise_datetime( (string) $payload['updated_on'] );
+        $now                   = current_time( 'mysql', true );
+
+        $existing = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT id FROM {$table} WHERE plugin_slug = %s AND new_version = %s AND updated_on = %s",
+                $payload['plugin_slug'],
+                $payload['new_version'],
+                $payload['updated_on']
+            )
+        );
+
+        if ( ! empty( $existing ) ) {
+            return true;
+        }
+
+        $inserted = $wpdb->insert(
+            $table,
+            array(
+                'plugin_slug'      => $payload['plugin_slug'],
+                'plugin_name'      => $payload['plugin_name'],
+                'previous_version' => $payload['previous_version'],
+                'new_version'      => $payload['new_version'],
+                'updated_on'       => $payload['updated_on'],
+                'source'           => $payload['source'],
+                'created_at'       => $now,
+                'updated_at'       => $now,
+            ),
+            array( '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' )
+        );
+
+        if ( false !== $inserted ) {
+            self::log( sprintf( 'Recorded plugin update for %s (%s → %s).', $payload['plugin_slug'], $payload['previous_version'], $payload['new_version'] ) );
+        }
+
+        return false !== $inserted;
+    }
+
+    /**
+     * Retrieve updates between two datetimes (inclusive).
+     */
+    public static function get_updates_between( string $start, string $end ): array {
+        global $wpdb;
+
+        $table = self::table();
+
+        if ( empty( $table ) || ! self::table_exists( $table ) ) {
+            return array();
+        }
+
+        $start = self::normalise_datetime( $start );
+        $end   = self::normalise_datetime( $end );
+
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT * FROM {$table} WHERE updated_on BETWEEN %s AND %s ORDER BY updated_on DESC, id DESC",
+                $start,
+                $end
+            ),
+            ARRAY_A
+        );
+
+        if ( ! is_array( $rows ) ) {
+            return array();
+        }
+
+        return array_map( 'wp_parse_args', $rows );
+    }
+
+    /**
+     * Retrieve updates for a given YYYY-MM period.
+     */
+    public static function get_updates_for_month( string $month ): array {
+        $start = gmdate( 'Y-m-01 00:00:00', strtotime( $month . '-01 00:00:00' ) );
+        $end   = gmdate( 'Y-m-t 23:59:59', strtotime( $month . '-01 00:00:00' ) );
+
+        return self::get_updates_between( $start, $end );
+    }
+
+    /**
+     * Return the most recent update row for a slug.
+     */
+    public static function get_latest_for_plugin( string $plugin_slug ): array {
+        global $wpdb;
+
+        $table = self::table();
+
+        if ( empty( $table ) || ! self::table_exists( $table ) ) {
+            return array();
+        }
+
+        $row = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT * FROM {$table} WHERE plugin_slug = %s ORDER BY updated_on DESC, id DESC LIMIT 1",
+                $plugin_slug
+            ),
+            ARRAY_A
+        );
+
+        return is_array( $row ) ? $row : array();
+    }
+
+    /**
+     * Run a one-time import of recent plugin updates from WordPress metadata.
+     */
+    public static function maybe_migrate_recent_history(): void {
+        if ( get_option( self::MIGRATION_OPTION, false ) ) {
+            return;
+        }
+
+        self::import_recent_updates();
+        update_option( self::MIGRATION_OPTION, true );
+    }
+
+    /**
+     * Capture plugin updates performed through the WordPress upgrader.
+     *
+     * @param \WP_Upgrader $upgrader   Upgrader instance.
+     * @param array         $hook_extra Context about the update run.
+     */
+    public static function capture_upgrader_event( $upgrader, array $hook_extra ): void {
+        $settings = Settings::get_settings();
+
+        if ( empty( $settings['track_update_history_internal'] ) ) {
+            return;
+        }
+
+        if ( ( $hook_extra['type'] ?? '' ) !== 'plugin' || empty( $hook_extra['plugins'] ) ) {
+            return;
+        }
+
+        if ( ! function_exists( 'get_plugins' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+
+        $plugins = get_plugins();
+        $now     = current_time( 'mysql', true );
+
+        foreach ( (array) $hook_extra['plugins'] as $plugin_file ) {
+            if ( ! isset( $plugins[ $plugin_file ] ) ) {
+                continue;
+            }
+
+            $slug         = sanitize_title( wp_basename( (string) $plugin_file ) );
+            $plugin_data  = $plugins[ $plugin_file ];
+            $new_version  = (string) ( $plugin_data['Version'] ?? '' );
+            $plugin_name  = (string) ( $plugin_data['Name'] ?? $slug );
+            $latest_entry = self::get_latest_for_plugin( $slug );
+            $old_version  = $latest_entry['new_version'] ?? (string) ( $plugin_data['Version'] ?? '' );
+
+            self::record_update(
+                array(
+                    'plugin_slug'      => $slug,
+                    'plugin_name'      => $plugin_name,
+                    'previous_version' => $old_version,
+                    'new_version'      => $new_version,
+                    'updated_on'       => $now,
+                    'source'           => 'auto',
+                )
+            );
+        }
+    }
+
+    /**
+     * Perform a best-effort import of recent update data from WordPress options.
+     */
+    private static function import_recent_updates(): void {
+        if ( ! function_exists( 'get_plugins' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+
+        $plugins            = get_plugins();
+        $update_plugins     = get_option( 'update_plugins', array() );
+        $auto_update_info   = get_option( 'auto_plugin_update_info', array() );
+        $cutoff_timestamp   = strtotime( '-30 days', current_time( 'timestamp', true ) );
+        $update_timestamps  = self::extract_auto_update_timestamps( $auto_update_info, $cutoff_timestamp );
+        $last_checked_value = isset( $update_plugins['last_checked'] ) ? (int) $update_plugins['last_checked'] : 0;
+
+        foreach ( $plugins as $file => $data ) {
+            $slug        = sanitize_title( wp_basename( (string) $file ) );
+            $plugin_name = (string) ( $data['Name'] ?? $slug );
+            $new_version = (string) ( $data['Version'] ?? '' );
+
+            $timestamps = $update_timestamps[ $slug ] ?? array();
+
+            if ( empty( $timestamps ) && $last_checked_value > $cutoff_timestamp ) {
+                $timestamps[] = $last_checked_value;
+            }
+
+            foreach ( $timestamps as $timestamp ) {
+                if ( $timestamp < $cutoff_timestamp ) {
+                    continue;
+                }
+
+                $updated_on = gmdate( 'Y-m-d H:i:s', $timestamp );
+
+                self::record_update(
+                    array(
+                        'plugin_slug'      => $slug,
+                        'plugin_name'      => $plugin_name,
+                        'previous_version' => '',
+                        'new_version'      => $new_version,
+                        'updated_on'       => $updated_on,
+                        'source'           => 'import',
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * Extract timestamps from auto-update metadata where possible.
+     *
+     * @param array $auto_update_info Option payload.
+     * @param int   $cutoff_timestamp Minimum timestamp to consider.
+     *
+     * @return array<string,array<int>>
+     */
+    private static function extract_auto_update_timestamps( array $auto_update_info, int $cutoff_timestamp ): array {
+        $events = array();
+
+        $sections = array( 'auto_updates', 'successful', 'failed', 'plugins', 'updates' );
+
+        foreach ( $sections as $key ) {
+            if ( empty( $auto_update_info[ $key ] ) || ! is_array( $auto_update_info[ $key ] ) ) {
+                continue;
+            }
+
+            foreach ( $auto_update_info[ $key ] as $plugin_key => $payload ) {
+                if ( is_array( $payload ) ) {
+                    $slug      = sanitize_title( wp_basename( (string) ( $payload['plugin'] ?? $plugin_key ) ) );
+                    $timestamp = (int) ( $payload['timestamp'] ?? $payload['time'] ?? $payload['when'] ?? $payload['last_checked'] ?? 0 );
+
+                    if ( $timestamp > $cutoff_timestamp ) {
+                        $events[ $slug ][] = $timestamp;
+                    }
+                }
+            }
+        }
+
+        return $events;
+    }
+
+    /**
+     * Verify the updates table exists before querying.
+     */
+    private static function table_exists( string $table ): bool {
+        global $wpdb;
+
+        $table_name = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+
+        return $table_name === $table;
+    }
+
+    /**
+     * Normalise a datetime string for storage.
+     */
+    private static function normalise_datetime( string $value ): string {
+        if ( empty( $value ) ) {
+            return current_time( 'mysql', true );
+        }
+
+        $timestamp = strtotime( $value );
+
+        if ( false === $timestamp ) {
+            return current_time( 'mysql', true );
+        }
+
+        return gmdate( 'Y-m-d H:i:s', $timestamp );
+    }
+
+    /**
+     * Log helper for update storage.
+     */
+    private static function log( string $message ): void {
+        if ( function_exists( 'satori_audit_log' ) ) {
+            satori_audit_log( '[Updates] ' . $message );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace Simple History-based history lookups with an internal update storage service and migration of recent WordPress data
- add the wp_satori_audit_updates table with CRUD helpers and wire it into report generation and PDF output
- surface a Track Update History (Internal) toggle in settings and guard runtime ingestion against it

## Testing
- composer validate
- php -l includes/class-satori-audit-update-storage.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e61628120832d8454fde1513e3eec)